### PR TITLE
fix: use remote host paths in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ jobs:
       CORAZON_MEMORY_CHROMA_TENANT: ${{ secrets.CORAZON_MEMORY_CHROMA_TENANT }}
       CORAZON_MEMORY_CHROMA_DATABASE: ${{ secrets.CORAZON_MEMORY_CHROMA_DATABASE }}
       CORAZON_PORT: ${{ secrets.CORAZON_PORT }}
+      CORAZON_HOST_STATE_DIR: /home/ubuntu
+      CORAZON_CODEX_HOST_DIR: /home/ubuntu/.codex
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -52,6 +54,14 @@ jobs:
 
       - name: Verify remote Docker connectivity
         run: docker --context production info >/dev/null
+
+      - name: Prepare remote bind mount directories
+        run: |
+          ssh "${{ secrets.DEPLOY_HOST }}" '
+            mkdir -p /home/ubuntu/.corazon /home/ubuntu/chroma
+            mkdir -p /home/ubuntu/.ssh
+            chmod 700 /home/ubuntu/.ssh
+          '
 
       - name: Print runner and remote architecture
         run: |


### PR DESCRIPTION
## Summary
- set explicit remote host bind paths for `CORAZON_HOST_STATE_DIR` and `CORAZON_CODEX_HOST_DIR` in the deploy workflow
- create the required `/home/ubuntu/.corazon`, `/home/ubuntu/.ssh`, and `/home/ubuntu/chroma` directories on the deploy host before `docker compose up`
- avoid letting the GitHub Actions runner `HOME` and checkout path leak into remote Docker bind mounts

## Why
The currently deployed container is mounting runner-side paths such as `/home/runner/.codex` and `/home/runner/work/.../.docker-state/.corazon` into the remote Docker engine. That leaves `/root/.codex-seed` empty on the server even though the real auth seed exists at `/home/ubuntu/.codex/auth.json`, so Codex startup fails for the deployed app.