### PR TITLE
Add workflow overload retry and model fallback

### DIFF
--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -22,7 +22,7 @@ let codexInstance: CodexClient | null = null
 let workflowRunnerInitialized = false
 const WORKFLOW_FINALIZATION_RETRY_LIMIT = 2
 
-const overloadErrorPattern = /(?:server[_\s-]?is[_\s-]?overloaded|at\s+capacity|temporar(?:y|ily)\s+unavailable|please\s+try\s+again)/i
+const overloadErrorPattern = /(?:server[_\s-]?is[_\s-]?overloaded|at\s+capacity|temporar(?:y|ily)\s+unavailable)/i
 
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
 


### PR DESCRIPTION
## Summary
- detect transient model overload errors during workflow execution
- retry overloaded attempts with bounded backoff when no tool/item activity has started
- fall back to a secondary workflow model when retries on the primary model are exhausted
- treat turn.failed as a real failure path so runs do not falsely complete

## Validation
- pnpm lint
- pnpm typecheck

Closes #33