### PR TITLE
fix: flush Telegram draft immediately on completion

### DIFF
--- a/server/utils/telegram-transport.ts
+++ b/server/utils/telegram-transport.ts
@@ -1356,10 +1356,17 @@ const processTelegramWorkflowRun = async (input: {
       textDraftLastSentAt.set(textId, now)
       textDraftLastSentText.set(textId, normalizedText)
     }
+    const flushAllTextDrafts = async (force: boolean) => {
+      const textIds = Array.from(textBuffer.keys())
+      for (const textId of textIds) {
+        await flushTextDraft(textId, force)
+      }
+    }
 
     while (true) {
       const { done, value } = await reader.read()
       if (done) {
+        await flushAllTextDrafts(true)
         break
       }
 
@@ -1376,6 +1383,7 @@ const processTelegramWorkflowRun = async (input: {
       if (isEventChunk(value) && value.data.kind === 'turn.completed') {
         turnCompleted = true
         typing.stop()
+        await flushAllTextDrafts(true)
         continue
       }
 


### PR DESCRIPTION
## Summary
- force-flush all buffered Telegram text drafts when `turn.completed` arrives
- force-flush buffered drafts again when the stream reader closes
- keep existing per-delta throttle behavior, but ensure terminal completion is not delayed by the throttle window

## Validation
- pnpm lint
- pnpm typecheck

Closes #35