### PR TITLE
fix: improve Telegram initial streaming chunk cadence

### DIFF
--- a/server/utils/telegram-transport.ts
+++ b/server/utils/telegram-transport.ts
@@ -1400,11 +1400,14 @@ const processTelegramWorkflowRun = async (input: {
       textDraftSentCount.set(textId, sentCount + 1)
     }
     const flushTextDraft = async (textId: string, force: boolean) => {
-      const inFlight = textDraftFlushInFlight.get(textId)
-      if (inFlight) {
-        await inFlight
-      }
-      const flushPromise = flushTextDraftInternal(textId, force)
+      // Chain per textId so concurrent callers cannot fan out into parallel flushes
+      // after awaiting the same in-flight promise.
+      const inFlight = textDraftFlushInFlight.get(textId) ?? Promise.resolve()
+      const flushPromise = inFlight
+        .catch(() => {})
+        .then(async () => {
+          await flushTextDraftInternal(textId, force)
+        })
       textDraftFlushInFlight.set(textId, flushPromise)
       try {
         await flushPromise


### PR DESCRIPTION
## Summary\n- buffer the first Telegram draft update until it reaches a meaningful minimum length, or a short max wait expires\n- send the second draft update on a much shorter interval than steady-state updates\n- keep existing steady-state draft throttling to avoid edit spam\n\n## Why\nTelegram streaming could publish a one-character first draft and then appear stalled due to draft update throttling.\n\n## Validation\n- pnpm lint\n- pnpm typecheck\n\nCloses #34