### PR TITLE
fix: add mobile sidebar toggle on /chat

### DIFF
--- a/app/pages/chat/index.vue
+++ b/app/pages/chat/index.vue
@@ -178,6 +178,16 @@ watch(pendingThreadId, async (value) => {
     @dragover="onDragOver"
     @drop="onDrop"
   >
+    <template #header>
+      <UDashboardNavbar>
+        <template #leading>
+          <UDashboardSidebarCollapse />
+        </template>
+        <template #title>
+          <span>Chat</span>
+        </template>
+      </UDashboardNavbar>
+    </template>
     <template #body>
       <div class="flex h-full min-h-0 flex-col">
         <UContainer


### PR DESCRIPTION
## Summary
- add a UDashboardNavbar to /chat index route
- add UDashboardSidebarCollapse in the navbar leading slot so mobile users can open and close the sidebar
- keep existing /chat composer and message stage behavior unchanged

## Why
/chat/[thread] already exposes sidebar controls via navbar, but /chat had no navbar so mobile users could not access sidebar navigation from that route.

## Validation
- pnpm lint
- pnpm typecheck

Closes #40