### PR TITLE
feat(workflow): restore self-evolution repo hygiene preflight

### DIFF
--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
 import type { WorkflowDefinition, WorkflowRunSummary, WorkflowTriggerType } from '@@/types/workflow'
 import { createCodexClient } from './codex-client/index.ts'
 import type { CodexClient, CodexThreadEvent, CodexUsage } from './codex-client/types.ts'
@@ -125,14 +126,19 @@ const runGitCommand = (
   try {
     const output = execFileSync('git', ['-C', repoPath, ...args], {
       encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe']
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: 10 * 1024 * 1024
     })
     return {
       ok: true,
       output
     } as const
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
+    const message = error instanceof Error
+      ? ('stderr' in error && error.stderr
+          ? `${error.message}\n${String(error.stderr).trim()}`
+          : error.message)
+      : String(error)
     return {
       ok: false,
       output: '',
@@ -146,7 +152,7 @@ const resolveSelfEvolutionRepoPath = () => {
   if (configured) {
     return configured
   }
-  return `${resolveCorazonRootDir()}/${SELF_EVOLUTION_REPO_DEFAULT_RELATIVE_PATH}`
+  return join(resolveCorazonRootDir(), SELF_EVOLUTION_REPO_DEFAULT_RELATIVE_PATH)
 }
 
 const collectSelfEvolutionRepoHygieneSnapshot = (): SelfEvolutionRepoHygieneSnapshot => {


### PR DESCRIPTION
## Summary
- restore self-evolution repository hygiene preflight in `server/utils/workflow-runner.ts`
- classify dirty worktree/detached head as manual intervention conditions
- classify `[gone]` tracking branches and merged local branches as auto-recoverable cleanup candidates
- inject hygiene snapshot into run context and require a `Repo hygiene` section in run reports
- fix gone-upstream detection by using `%(upstream:track)` output (not `trackshort`)

## Validation
- `pnpm lint`
- `pnpm typecheck`

Closes #76
