### PR TITLE
Refactor auth seed bootstrap/setup logic into shared utility

### DIFF
--- a/lib/auth-seed-utils.d.ts
+++ b/lib/auth-seed-utils.d.ts
@@ -1,0 +1,16 @@
+export type AuthSeedMode = 'link' | 'copy-once'
+
+export interface EnsureCopiedAuthFileOptions {
+  sourcePath: string
+  destinationPath: string
+  overwrite?: boolean
+  skipIfExistingNonSymlink?: boolean
+  onSkip?: () => void
+  onCopy?: () => void
+}
+
+export declare const resolveAuthSeedMode: (rawMode?: string | undefined) => AuthSeedMode
+
+export declare const ensureCopiedAuthFile: (
+  options: EnsureCopiedAuthFileOptions
+) => 'copied' | 'skipped' | 'missing-source'

--- a/lib/auth-seed-utils.js
+++ b/lib/auth-seed-utils.js
@@ -1,0 +1,47 @@
+import { copyFileSync, existsSync, lstatSync, mkdirSync, rmSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+const AUTH_SEED_COPY_ALIASES = new Set(['copy', 'copy-once', 'seed-copy'])
+
+export const resolveAuthSeedMode = (rawMode = process.env.CORAZON_AUTH_SEED_MODE) => {
+  const raw = rawMode?.trim().toLowerCase()
+  if (raw && AUTH_SEED_COPY_ALIASES.has(raw)) {
+    return 'copy-once'
+  }
+  return 'link'
+}
+
+export const ensureCopiedAuthFile = ({
+  sourcePath,
+  destinationPath,
+  overwrite = false,
+  skipIfExistingNonSymlink = true,
+  onSkip,
+  onCopy
+}) => {
+  if (!existsSync(sourcePath)) {
+    onSkip?.()
+    return 'missing-source'
+  }
+
+  if (existsSync(destinationPath) && !overwrite && skipIfExistingNonSymlink) {
+    try {
+      const destinationStats = lstatSync(destinationPath)
+      if (!destinationStats.isSymbolicLink()) {
+        onSkip?.()
+        return 'skipped'
+      }
+    } catch {
+      // Fall through and try to replace the existing entry.
+    }
+  }
+
+  if (existsSync(destinationPath)) {
+    rmSync(destinationPath, { recursive: true, force: true })
+  }
+
+  mkdirSync(dirname(destinationPath), { recursive: true })
+  copyFileSync(sourcePath, destinationPath)
+  onCopy?.()
+  return 'copied'
+}

--- a/lib/auth-seed-utils.js
+++ b/lib/auth-seed-utils.js
@@ -3,6 +3,15 @@ import { dirname } from 'node:path'
 
 const AUTH_SEED_COPY_ALIASES = new Set(['copy', 'copy-once', 'seed-copy'])
 
+const pathExists = (path) => {
+  try {
+    lstatSync(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
 export const resolveAuthSeedMode = (rawMode = process.env.CORAZON_AUTH_SEED_MODE) => {
   const raw = rawMode?.trim().toLowerCase()
   if (raw && AUTH_SEED_COPY_ALIASES.has(raw)) {
@@ -24,7 +33,9 @@ export const ensureCopiedAuthFile = ({
     return 'missing-source'
   }
 
-  if (existsSync(destinationPath) && !overwrite && skipIfExistingNonSymlink) {
+  const destinationExists = pathExists(destinationPath)
+
+  if (destinationExists && !overwrite && skipIfExistingNonSymlink) {
     try {
       const destinationStats = lstatSync(destinationPath)
       if (!destinationStats.isSymbolicLink()) {
@@ -36,7 +47,7 @@ export const ensureCopiedAuthFile = ({
     }
   }
 
-  if (existsSync(destinationPath)) {
+  if (destinationExists) {
     rmSync(destinationPath, { recursive: true, force: true })
   }
 

--- a/scripts/corazon-setup.mjs
+++ b/scripts/corazon-setup.mjs
@@ -15,6 +15,7 @@ import {
 import { homedir } from 'node:os'
 import { dirname, join, relative, resolve as resolvePath } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { ensureCopiedAuthFile, resolveAuthSeedMode } from '../lib/auth-seed-utils.js'
 
 const SEED_DIRECTORIES = ['skills', 'rules', 'vendor_imports']
 const AUTH_FILE = 'auth.json'
@@ -31,14 +32,6 @@ const UPDATED_SHARED_MEMORY_GUIDANCE = [
   '- For memory reads/writes in a task, follow the skill workflow: `ensure`, then `search`, then `upsert`.',
   '- Add memory when new stable facts/preferences/decisions emerge; search memory when prior context is needed.'
 ].join('\n')
-
-const resolveAuthSeedMode = () => {
-  const raw = process.env.CORAZON_AUTH_SEED_MODE?.trim().toLowerCase()
-  if (raw === 'copy' || raw === 'copy-once' || raw === 'seed-copy') {
-    return 'copy-once'
-  }
-  return 'link'
-}
 
 const getPlatformDefaultRuntimeRoot = () => {
   if (process.platform === 'darwin') {
@@ -272,33 +265,6 @@ const ensureLinkedAuthFile = (sourcePath, destinationPath, overwrite, counters) 
   counters.linked += 1
 }
 
-const ensureCopiedAuthFile = (sourcePath, destinationPath, overwrite, counters) => {
-  if (!existsSync(sourcePath)) {
-    counters.skipped += 1
-    return
-  }
-
-  if (pathExists(destinationPath) && !overwrite) {
-    try {
-      const destinationStats = lstatSync(destinationPath)
-      if (!destinationStats.isSymbolicLink()) {
-        counters.skipped += 1
-        return
-      }
-    } catch {
-      // Fall through and try to replace the existing entry.
-    }
-  }
-
-  if (pathExists(destinationPath)) {
-    rmSync(destinationPath, { recursive: true, force: true })
-  }
-
-  mkdirSync(dirname(destinationPath), { recursive: true })
-  copyFileSync(sourcePath, destinationPath)
-  counters.copied += 1
-}
-
 const ensureAgentsFile = (runtimeRoot, overwrite, counters) => {
   const destinationPath = join(runtimeRoot, AGENTS_FILE)
   if (existsSync(destinationPath) && !overwrite) {
@@ -522,7 +488,17 @@ export const run = (args = []) => {
     const sourceAuthPath = join(codexHome, AUTH_FILE)
     const destinationAuthPath = join(agentHome, AUTH_FILE)
     if (resolveAuthSeedMode() === 'copy-once') {
-      ensureCopiedAuthFile(sourceAuthPath, destinationAuthPath, options.overwrite, counters)
+      ensureCopiedAuthFile({
+        sourcePath: sourceAuthPath,
+        destinationPath: destinationAuthPath,
+        overwrite: options.overwrite,
+        onSkip: () => {
+          counters.skipped += 1
+        },
+        onCopy: () => {
+          counters.copied += 1
+        }
+      })
     } else {
       ensureLinkedAuthFile(sourceAuthPath, destinationAuthPath, options.overwrite, counters)
     }

--- a/server/utils/agent-bootstrap.ts
+++ b/server/utils/agent-bootstrap.ts
@@ -17,6 +17,7 @@ import {
   getDefaultCodexSeedSourceDir,
   resolveCorazonRootDir
 } from './agent-home.ts'
+import { ensureCopiedAuthFile, resolveAuthSeedMode } from '@@/lib/auth-seed-utils.js'
 
 const SEED_FILES = ['config.toml'] as const
 const SEED_DIRECTORIES = ['skills', 'rules', 'vendor_imports'] as const
@@ -65,8 +66,6 @@ const OPERATOR_NOTIFICATION_GUIDANCE = [
 ].join('\n')
 
 let bootstrapDone = false
-
-type AuthSeedMode = 'link' | 'copy-once'
 
 const pathExists = (targetPath: string) => {
   try {
@@ -168,36 +167,6 @@ const ensureLinkedAuthFile = (sourcePath: string, destinationPath: string) => {
   }
   mkdirSync(dirname(destinationPath), { recursive: true })
   symlinkSync(getSymlinkTarget(sourcePath, destinationPath), destinationPath, 'file')
-}
-
-const ensureCopiedAuthFile = (sourcePath: string, destinationPath: string) => {
-  if (!existsSync(sourcePath)) {
-    return
-  }
-
-  if (pathExists(destinationPath)) {
-    try {
-      const destinationStats = lstatSync(destinationPath)
-      if (!destinationStats.isSymbolicLink()) {
-        return
-      }
-    } catch {
-      // Fall through and try to replace the existing entry.
-    }
-
-    rmSync(destinationPath, { recursive: true, force: true })
-  }
-
-  mkdirSync(dirname(destinationPath), { recursive: true })
-  copyFileSync(sourcePath, destinationPath)
-}
-
-const resolveAuthSeedMode = (): AuthSeedMode => {
-  const raw = process.env.CORAZON_AUTH_SEED_MODE?.trim().toLowerCase()
-  if (raw === 'copy' || raw === 'copy-once' || raw === 'seed-copy') {
-    return 'copy-once'
-  }
-  return 'link'
 }
 
 const ensureSeededFile = (sourcePath: string, destinationPath: string) => {
@@ -400,7 +369,7 @@ export const ensureAgentBootstrap = () => {
     const sourceAuthPath = join(sourceRootDir, AUTH_FILE)
     const destinationAuthPath = join(agentHomeDir, AUTH_FILE)
     if (resolveAuthSeedMode() === 'copy-once') {
-      ensureCopiedAuthFile(sourceAuthPath, destinationAuthPath)
+      ensureCopiedAuthFile({ sourcePath: sourceAuthPath, destinationPath: destinationAuthPath })
     } else {
       ensureLinkedAuthFile(sourceAuthPath, destinationAuthPath)
     }


### PR DESCRIPTION
## Summary
- extract duplicated auth-seed mode parsing into `lib/auth-seed-utils.js`
- extract shared `ensureCopiedAuthFile` behavior into the same utility and reuse it from both bootstrap/setup paths
- keep setup-specific overwrite and counters behavior via callbacks so existing setup output semantics stay intact

## Validation
- `pnpm lint`
- `pnpm typecheck`

Closes #86
