### PR TITLE
feat: add workflow language frontmatter scaffolding

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -20,6 +20,13 @@ CORAZON_HOST_STATE_DIR=./.docker-state
 CORAZON_MEMORY_CHROMA_COLLECTION=mem0
 CORAZON_MEMORY_SYNC_ENABLED=true
 MEM0_TELEMETRY=false
+# Workflow script sandbox (language: `typescript`/`python`) settings.
+# Current provider support: `local` only.
+# CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER=local
+# Script execution timeout in milliseconds (default: 60000).
+# CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS=60000
+# Optional Python runtime binary for `language: python` workflows.
+# CORAZON_WORKFLOW_PYTHON_BIN=python3
 # Optional: Chroma Cloud
 # CORAZON_MEMORY_CHROMA_API_KEY=
 # CORAZON_MEMORY_CHROMA_TENANT=

--- a/.env.dist
+++ b/.env.dist
@@ -25,6 +25,10 @@ MEM0_TELEMETRY=false
 # CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER=local
 # Script execution timeout in milliseconds (default: 60000).
 # CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS=60000
+# Script output cap in bytes (default: 256000, minimum: 1024).
+# CORAZON_WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES=256000
+# Comma-separated env allowlist injected into script runs (default: empty).
+# CORAZON_WORKFLOW_SCRIPT_ENV_ALLOWLIST=MY_API_BASE_URL,MY_PUBLIC_TOKEN
 # Optional Python runtime binary for `language: python` workflows.
 # CORAZON_WORKFLOW_PYTHON_BIN=python3
 # Optional: Chroma Cloud

--- a/.env.dist
+++ b/.env.dist
@@ -27,6 +27,8 @@ MEM0_TELEMETRY=false
 # CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS=60000
 # Script output cap in bytes (default: 256000, minimum: 1024).
 # CORAZON_WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES=256000
+# Script source-size cap in bytes (default: 64000, minimum: 256).
+# CORAZON_WORKFLOW_SCRIPT_MAX_SOURCE_BYTES=64000
 # Comma-separated env allowlist injected into script runs (default: empty).
 # CORAZON_WORKFLOW_SCRIPT_ENV_ALLOWLIST=MY_API_BASE_URL,MY_PUBLIC_TOKEN
 # Optional Python runtime binary for `language: python` workflows.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Note:
 - `language: typescript` and `language: python` workflows run through the script sandbox provider path.
 - Script runs expose provider metadata (`provider`, `language`, `trigger`, timeout/output/source policy) in failure summaries for faster triage.
 - Failure summaries also include `failurePhase` (`prepare`/`execute`) for `provider-error` cases to separate setup/runtime bootstrap failures from script logic failures.
-- Script sandbox metadata now includes `executionDurationMs` and `outputTruncated`; failure summaries include these values for faster policy/provider triage without log scraping.
+- Script sandbox metadata now includes phase-level timing (`prepareDurationMs`, `executeDurationMs`, `teardownDurationMs`) plus `executionDurationMs` and `outputTruncated`; failure summaries include these values for faster policy/provider triage without log scraping.
 - Managed sandbox providers are planned as follow-up adapters behind the same provider interface.
 
 Script sandbox triage quick map:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Note:
 - `language: typescript` and `language: python` workflows run through the script sandbox provider path.
 - Script runs expose provider metadata (`provider`, `language`, `trigger`, timeout/output/source policy) in failure summaries for faster triage.
 - Failure summaries also include `failurePhase` (`prepare`/`execute`) for `provider-error` cases to separate setup/runtime bootstrap failures from script logic failures.
+- Script sandbox metadata now includes `executionDurationMs`, and failure summaries include that value for faster policy/provider triage without log scraping.
 - Managed sandbox providers are planned as follow-up adapters behind the same provider interface.
 
 The app runs at:

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Note:
 - `language: typescript` and `language: python` workflows run through the script sandbox provider path.
 - Script runs expose provider metadata (`provider`, `language`, `trigger`, timeout/output/source policy) in failure summaries for faster triage.
 - Failure summaries also include `failurePhase` (`prepare`/`execute`) for `provider-error` cases to separate setup/runtime bootstrap failures from script logic failures.
-- Script sandbox metadata now includes `executionDurationMs`, and failure summaries include that value for faster policy/provider triage without log scraping.
+- Script sandbox metadata now includes `executionDurationMs` and `outputTruncated`; failure summaries include these values for faster policy/provider triage without log scraping.
 - Managed sandbox providers are planned as follow-up adapters behind the same provider interface.
 
 Script sandbox triage quick map:
 - `errorCode=execution-timeout`: script exceeded `CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS`; check `executionDurationMs`, then reduce workload or raise timeout cautiously.
-- `errorCode=policy-violation` + `policyTrigger=output-size`: combined stdout/stderr exceeded `CORAZON_WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES`; reduce log volume or adjust output cap.
+- `errorCode=policy-violation` + `policyTrigger=output-size`: combined stdout/stderr exceeded `CORAZON_WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES`; reduce log volume or adjust output cap. If `outputTruncated=true`, captured logs were capped at the configured output budget.
 - `errorCode=policy-violation` + `policyTrigger=source-size`: workflow body exceeded `CORAZON_WORKFLOW_SCRIPT_MAX_SOURCE_BYTES`; move logic into smaller units or increase source-size cap cautiously.
 - `errorCode=provider-error` + `failurePhase=prepare`: provider/runtime bootstrap failed before script execution (for example missing runtime binary); verify runtime dependencies and provider config.
 - `errorCode=provider-error` + `failurePhase=execute`: provider failed after process start; use `executionDurationMs`, `terminationScope`, and runtime command metadata to inspect teardown and subprocess behavior.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ Optional runtime mode:
 - `CORAZON_CODEX_CLIENT_MODE=app-server` (default)
 - `CORAZON_CODEX_CLIENT_MODE=sdk` (fallback)
 
+Workflow script sandbox runtime:
+- `CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER=local` (default; currently the only supported provider)
+- `CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS=60000` default timeout for script-language workflow runs
+- `CORAZON_WORKFLOW_PYTHON_BIN=python3` optional Python binary override for `language: python` workflows
+
+Note:
+- `language: markdown` workflows continue to use the LLM execution path.
+- `language: typescript` and `language: python` workflows run through the script sandbox provider path.
+- Managed sandbox providers are planned as follow-up adapters behind the same provider interface.
+
 The app runs at:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Note:
 - `language: markdown` workflows continue to use the LLM execution path.
 - `language: typescript` and `language: python` workflows run through the script sandbox provider path.
 - Script runs expose provider metadata (`provider`, `language`, `trigger`, timeout/output/source policy) in failure summaries for faster triage.
+- Failure summaries also include `failurePhase` (`prepare`/`execute`) for `provider-error` cases to separate setup/runtime bootstrap failures from script logic failures.
 - Managed sandbox providers are planned as follow-up adapters behind the same provider interface.
 
 The app runs at:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Note:
 - Script sandbox metadata now includes `executionDurationMs`, and failure summaries include that value for faster policy/provider triage without log scraping.
 - Managed sandbox providers are planned as follow-up adapters behind the same provider interface.
 
+Script sandbox triage quick map:
+- `errorCode=execution-timeout`: script exceeded `CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS`; check `executionDurationMs`, then reduce workload or raise timeout cautiously.
+- `errorCode=policy-violation` + `policyTrigger=output-size`: combined stdout/stderr exceeded `CORAZON_WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES`; reduce log volume or adjust output cap.
+- `errorCode=policy-violation` + `policyTrigger=source-size`: workflow body exceeded `CORAZON_WORKFLOW_SCRIPT_MAX_SOURCE_BYTES`; move logic into smaller units or increase source-size cap cautiously.
+- `errorCode=provider-error` + `failurePhase=prepare`: provider/runtime bootstrap failed before script execution (for example missing runtime binary); verify runtime dependencies and provider config.
+- `errorCode=provider-error` + `failurePhase=execute`: provider failed after process start; use `executionDurationMs`, `terminationScope`, and runtime command metadata to inspect teardown and subprocess behavior.
+- `errorCode=execution-failed`: script process returned non-zero exit code; treat as script logic/runtime failure and inspect stderr with the captured metadata context.
+
 The app runs at:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Workflow script sandbox runtime:
 Note:
 - `language: markdown` workflows continue to use the LLM execution path.
 - `language: typescript` and `language: python` workflows run through the script sandbox provider path.
+- Script runtime now pins `HOME` and `TMPDIR` to the per-run temporary sandbox directory instead of inheriting host home paths.
 - Script runs expose provider metadata (`provider`, `language`, `trigger`, timeout/output/source policy) in failure summaries for faster triage.
 - Failure summaries also include `failurePhase` (`prepare`/`execute`) for `provider-error` cases to separate setup/runtime bootstrap failures from script logic failures.
 - Script sandbox metadata now includes phase-level timing (`prepareDurationMs`, `executeDurationMs`, `teardownDurationMs`) plus `executionDurationMs` and `outputTruncated`; failure summaries include these values for faster policy/provider triage without log scraping.

--- a/README.md
+++ b/README.md
@@ -49,11 +49,14 @@ Optional runtime mode:
 Workflow script sandbox runtime:
 - `CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER=local` (default; currently the only supported provider)
 - `CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS=60000` default timeout for script-language workflow runs
+- `CORAZON_WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES=256000` output cap for script-language workflow stdout/stderr
+- `CORAZON_WORKFLOW_SCRIPT_ENV_ALLOWLIST=KEY_A,KEY_B` comma-separated host env keys allowed into script runtime
 - `CORAZON_WORKFLOW_PYTHON_BIN=python3` optional Python binary override for `language: python` workflows
 
 Note:
 - `language: markdown` workflows continue to use the LLM execution path.
 - `language: typescript` and `language: python` workflows run through the script sandbox provider path.
+- Script runs expose provider metadata (`provider`, `language`, `trigger`, timeout/output policy) in failure summaries for faster triage.
 - Managed sandbox providers are planned as follow-up adapters behind the same provider interface.
 
 The app runs at:

--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ Workflow script sandbox runtime:
 - `CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER=local` (default; currently the only supported provider)
 - `CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS=60000` default timeout for script-language workflow runs
 - `CORAZON_WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES=256000` output cap for script-language workflow stdout/stderr
+- `CORAZON_WORKFLOW_SCRIPT_MAX_SOURCE_BYTES=64000` source-size cap for script-language workflow bodies
 - `CORAZON_WORKFLOW_SCRIPT_ENV_ALLOWLIST=KEY_A,KEY_B` comma-separated host env keys allowed into script runtime
 - `CORAZON_WORKFLOW_PYTHON_BIN=python3` optional Python binary override for `language: python` workflows
 
 Note:
 - `language: markdown` workflows continue to use the LLM execution path.
 - `language: typescript` and `language: python` workflows run through the script sandbox provider path.
-- Script runs expose provider metadata (`provider`, `language`, `trigger`, timeout/output policy) in failure summaries for faster triage.
+- Script runs expose provider metadata (`provider`, `language`, `trigger`, timeout/output/source policy) in failure summaries for faster triage.
 - Managed sandbox providers are planned as follow-up adapters behind the same provider interface.
 
 The app runs at:

--- a/app/pages/workflows/[name]/index.vue
+++ b/app/pages/workflows/[name]/index.vue
@@ -108,6 +108,7 @@ const saveWorkflow = async () => {
   const payload: WorkflowUpsertRequest = {
     name: form.name.trim(),
     description: form.description.trim(),
+    language: workflow.value?.frontmatter.language ?? 'markdown',
     instruction: form.instruction.trim(),
     skills: [...new Set(form.skills)],
     triggerType: hasTrigger ? form.triggerType : null,

--- a/app/pages/workflows/index.vue
+++ b/app/pages/workflows/index.vue
@@ -212,6 +212,7 @@ const saveWorkflow = async () => {
   const payload: WorkflowUpsertRequest = {
     name: form.workflowName || deriveWorkflowName(instruction),
     description: generatedDescription.value || deriveWorkflowDescription(instruction),
+    language: 'markdown',
     instruction,
     skills: [...new Set(form.skills)],
     triggerType: hasTrigger ? form.triggerType : null,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "postinstall": "nuxt prepare",
     "setup": "node scripts/corazon-setup.mjs",
     "lint": "eslint .",
-    "typecheck": "nuxt typecheck"
+    "typecheck": "nuxt typecheck",
+    "workflows:language:smoke": "node scripts/workflow-language-regression-smoke.ts"
   },
   "bin": {
     "corazon": "bin/corazon.js"

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict'
+import { parseWorkflowSource, serializeWorkflowSource } from '../server/utils/workflow-definitions.ts'
+import type { WorkflowFrontmatter } from '../types/workflow.ts'
+
+const baseFrontmatter = (language: WorkflowFrontmatter['language']): WorkflowFrontmatter => ({
+  name: 'Daily Summary',
+  description: 'Summarize the latest activity.',
+  language,
+  on: { 'workflow-dispatch': true },
+  skills: []
+})
+
+const run = () => {
+  const markdownSource = serializeWorkflowSource(
+    {
+      ...baseFrontmatter('markdown'),
+      on: {
+        'schedule': '13 * * * *',
+        'workflow-dispatch': true
+      }
+    },
+    '  Every day run this task.  \n\n   Send a concise report.  '
+  )
+
+  const markdown = parseWorkflowSource({
+    fileSlug: 'daily-summary',
+    filePath: '/tmp/daily-summary.md',
+    source: markdownSource,
+    updatedAt: Date.now()
+  })
+
+  assert.equal(markdown.isValid, true)
+  assert.equal(markdown.frontmatter.language, 'markdown')
+  assert.equal(markdown.frontmatter.on.schedule, '13 * * * *')
+  assert.equal(markdown.instruction.includes('<goal>'), true)
+  assert.equal(markdown.instruction.includes('Send a concise report.'), true)
+
+  const pythonSource = serializeWorkflowSource(
+    baseFrontmatter('python'),
+    'for item in [1, 2]:\n    print(item)\n'
+  )
+
+  const python = parseWorkflowSource({
+    fileSlug: 'python-dispatch',
+    filePath: '/tmp/python-dispatch.md',
+    source: pythonSource,
+    updatedAt: Date.now()
+  })
+
+  assert.equal(python.isValid, true)
+  assert.equal(python.frontmatter.language, 'python')
+  assert.equal(python.frontmatter.on['workflow-dispatch'], true)
+  assert.equal(python.frontmatter.on.schedule, undefined)
+  assert.equal(python.frontmatter.on.interval, undefined)
+  assert.equal(python.frontmatter.on.rrule, undefined)
+  assert.equal(
+    python.instruction,
+    'for item in [1, 2]:\n    print(item)',
+    'script workflows should preserve code body except leading/trailing whitespace trim'
+  )
+
+  assert.throws(
+    () => serializeWorkflowSource(
+      {
+        ...baseFrontmatter('python'),
+        on: {
+          'schedule': '*/5 * * * *',
+          'workflow-dispatch': false
+        }
+      },
+      'print("hi")'
+    ),
+    /Time triggers \("schedule", "interval", "rrule"\) currently support only markdown workflows\./,
+    'non-markdown workflows with time triggers must fail validation'
+  )
+
+  const invalidLanguage = parseWorkflowSource({
+    fileSlug: 'invalid-language',
+    filePath: '/tmp/invalid-language.md',
+    source: [
+      '---',
+      'name: Invalid Language',
+      'description: should fail',
+      'language: javascript',
+      'on:',
+      '  workflow-dispatch: true',
+      'skills: []',
+      '---',
+      'do work'
+    ].join('\n'),
+    updatedAt: Date.now()
+  })
+
+  assert.equal(invalidLanguage.isValid, false)
+  assert.match(invalidLanguage.parseError ?? '', /Frontmatter must include name, description, language, on, skills\./)
+
+  const typescriptSource = serializeWorkflowSource(
+    baseFrontmatter('typescript'),
+    'console.log("ok")'
+  )
+  const typescript = parseWorkflowSource({
+    fileSlug: 'typescript-dispatch',
+    filePath: '/tmp/typescript-dispatch.md',
+    source: typescriptSource,
+    updatedAt: Date.now()
+  })
+
+  assert.equal(typescript.isValid, true)
+  assert.equal(typescript.frontmatter.language, 'typescript')
+  assert.equal(typescript.frontmatter.on['workflow-dispatch'], true)
+  assert.equal(typescript.frontmatter.on.schedule, undefined)
+  assert.equal(typescript.frontmatter.on.interval, undefined)
+  assert.equal(typescript.frontmatter.on.rrule, undefined)
+
+  console.log('workflow language regression smoke checks passed')
+}
+
+run()

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -129,6 +129,24 @@ const run = async () => {
   assert.match(pythonExecuted.stdout, /1/)
   assert.match(pythonExecuted.stdout, /2/)
 
+  const previousProvider = process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER
+  process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER = ''
+  const pythonWithBlankProvider = await executeScriptWorkflowInSandbox({
+    definition: python,
+    triggerType: 'workflow-dispatch',
+    triggerValue: 'manual'
+  })
+  if (typeof previousProvider === 'string') {
+    process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER = previousProvider
+  } else {
+    delete process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER
+  }
+  assert.equal(
+    pythonWithBlankProvider.status,
+    'completed',
+    'empty sandbox provider env should fall back to local provider'
+  )
+
   const failedScriptSource = serializeWorkflowSource(
     baseFrontmatter('typescript'),
     'console.error("boom"); process.exit(7)'

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -129,6 +129,7 @@ const run = async () => {
   assert.equal(completedScriptRun.metadata.runtimeCommand, 'node')
   assert.deepEqual(completedScriptRun.metadata.runtimeArgs, ['script.mjs'])
   assert.equal(completedScriptRun.metadata.policyTriggered, 'none')
+  assert.equal(completedScriptRun.metadata.terminationScope, 'none')
 
   const pythonExecuted = await executeScriptWorkflowInSandbox({
     definition: python,
@@ -251,6 +252,10 @@ const run = async () => {
   }
   assert.equal(timedOutScriptRun.status, 'failed')
   assert.equal(timedOutScriptRun.errorCode, 'execution-timeout')
+  assert.equal(
+    ['process-group', 'process'].includes(timedOutScriptRun.metadata.terminationScope),
+    true
+  )
 
   const outputPolicySource = serializeWorkflowSource(
     baseFrontmatter('python'),
@@ -279,6 +284,10 @@ const run = async () => {
   assert.match(outputPolicyRun.errorMessage, /exceeded 1024 bytes/)
   assert.equal(outputPolicyRun.metadata.policyTriggered, 'output-size')
   assert.equal(outputPolicyRun.metadata.totalOutputBytes > 1024, true)
+  assert.equal(
+    ['process-group', 'process'].includes(outputPolicyRun.metadata.terminationScope),
+    true
+  )
 
   const sourcePolicySource = serializeWorkflowSource(
     baseFrontmatter('python'),

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -132,6 +132,9 @@ const run = async () => {
   assert.equal(completedScriptRun.metadata.terminationScope, 'none')
   assert.equal(completedScriptRun.metadata.outputTruncated, false)
   assert.equal(completedScriptRun.metadata.executionDurationMs, completedScriptRun.durationMs)
+  assert.equal(completedScriptRun.metadata.prepareDurationMs >= 0, true)
+  assert.equal(completedScriptRun.metadata.executeDurationMs >= 0, true)
+  assert.equal(completedScriptRun.metadata.teardownDurationMs >= 0, true)
 
   const pythonExecuted = await executeScriptWorkflowInSandbox({
     definition: python,
@@ -168,6 +171,9 @@ const run = async () => {
   assert.equal(providerFailureRun.errorCode, 'provider-error')
   assert.equal(providerFailureRun.metadata.failurePhase, 'execute')
   assert.equal(providerFailureRun.metadata.executionDurationMs, providerFailureRun.durationMs)
+  assert.equal(providerFailureRun.metadata.prepareDurationMs >= 0, true)
+  assert.equal(providerFailureRun.metadata.executeDurationMs >= 0, true)
+  assert.equal(providerFailureRun.metadata.teardownDurationMs >= 0, true)
   assert.match(providerFailureRun.errorMessage, /Failed to start script runtime/)
 
   const previousProvider = process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER
@@ -305,6 +311,9 @@ const run = async () => {
   assert.equal(outputPolicyRun.metadata.policyTriggered, 'output-size')
   assert.equal(outputPolicyRun.metadata.outputTruncated, true)
   assert.equal(outputPolicyRun.metadata.executionDurationMs, outputPolicyRun.durationMs)
+  assert.equal(outputPolicyRun.metadata.prepareDurationMs >= 0, true)
+  assert.equal(outputPolicyRun.metadata.executeDurationMs >= 0, true)
+  assert.equal(outputPolicyRun.metadata.teardownDurationMs >= 0, true)
   assert.equal(outputPolicyRun.metadata.totalOutputBytes > 1024, true)
   assert.equal(
     ['process-group', 'process'].includes(outputPolicyRun.metadata.terminationScope),
@@ -338,6 +347,9 @@ const run = async () => {
   assert.match(sourcePolicyRun.errorMessage, /source exceeded 256 bytes/)
   assert.equal(sourcePolicyRun.metadata.policyTriggered, 'source-size')
   assert.equal(sourcePolicyRun.metadata.executionDurationMs, sourcePolicyRun.durationMs)
+  assert.equal(sourcePolicyRun.metadata.prepareDurationMs, 0)
+  assert.equal(sourcePolicyRun.metadata.executeDurationMs, 0)
+  assert.equal(sourcePolicyRun.metadata.teardownDurationMs, 0)
 
   console.log('workflow language regression smoke checks passed')
 }

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { mkdir } from 'node:fs/promises'
 import { parseWorkflowSource, serializeWorkflowSource } from '../server/utils/workflow-definitions.ts'
 import { executeScriptWorkflowInSandbox } from '../server/utils/workflow-script-sandbox.ts'
 import type { WorkflowFrontmatter } from '../types/workflow.ts'
@@ -244,6 +245,51 @@ const run = async () => {
   assert.equal(sandboxHome?.startsWith('/tmp/corazon-workflow-script-') ?? false, true)
   assert.equal(sandboxTmpDir?.startsWith('/tmp/corazon-workflow-script-') ?? false, true)
   assert.deepEqual(envPolicyRun.metadata.allowedEnvKeys, ['CORAZON_TEST_ALLOWED_ENV'])
+
+  const previousHostHome = process.env.HOME
+  const previousHostTmpDir = process.env.TMPDIR
+  const previousAllowedEnvForReserved = process.env.CORAZON_TEST_ALLOWED_ENV
+  await mkdir('/tmp/corazon-host-home', { recursive: true })
+  await mkdir('/tmp/corazon-host-tmp', { recursive: true })
+  process.env.CORAZON_WORKFLOW_SCRIPT_ENV_ALLOWLIST = 'CORAZON_TEST_ALLOWED_ENV,HOME,TMPDIR'
+  process.env.CORAZON_TEST_ALLOWED_ENV = 'allowed'
+  process.env.HOME = '/tmp/corazon-host-home'
+  process.env.TMPDIR = '/tmp/corazon-host-tmp'
+  const reservedEnvPolicyRun = await executeScriptWorkflowInSandbox({
+    definition: envPolicyWorkflow,
+    triggerType: 'workflow-dispatch',
+    triggerValue: 'manual'
+  })
+  if (typeof previousAllowlist === 'string') {
+    process.env.CORAZON_WORKFLOW_SCRIPT_ENV_ALLOWLIST = previousAllowlist
+  } else {
+    delete process.env.CORAZON_WORKFLOW_SCRIPT_ENV_ALLOWLIST
+  }
+  if (typeof previousHostHome === 'string') {
+    process.env.HOME = previousHostHome
+  } else {
+    delete process.env.HOME
+  }
+  if (typeof previousHostTmpDir === 'string') {
+    process.env.TMPDIR = previousHostTmpDir
+  } else {
+    delete process.env.TMPDIR
+  }
+  if (typeof previousAllowedEnvForReserved === 'string') {
+    process.env.CORAZON_TEST_ALLOWED_ENV = previousAllowedEnvForReserved
+  } else {
+    delete process.env.CORAZON_TEST_ALLOWED_ENV
+  }
+  assert.equal(reservedEnvPolicyRun.status, 'completed')
+  assert.match(reservedEnvPolicyRun.stdout, /ALLOWED=allowed/)
+  const reservedSandboxHome = reservedEnvPolicyRun.stdout.match(/^HOME=(.+)$/m)?.[1] ?? null
+  const reservedSandboxTmpDir = reservedEnvPolicyRun.stdout.match(/^TMPDIR=(.+)$/m)?.[1] ?? null
+  assert.equal(typeof reservedSandboxHome, 'string')
+  assert.equal(typeof reservedSandboxTmpDir, 'string')
+  assert.equal(reservedSandboxHome === '/tmp/corazon-host-home', false)
+  assert.equal(reservedSandboxTmpDir === '/tmp/corazon-host-tmp', false)
+  assert.equal(reservedSandboxHome?.includes('corazon-workflow-script-') ?? false, true)
+  assert.equal(reservedSandboxTmpDir?.includes('corazon-workflow-script-') ?? false, true)
 
   const failedScriptSource = serializeWorkflowSource(
     baseFrontmatter('typescript'),

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -126,6 +126,9 @@ const run = async () => {
   assert.equal(completedScriptRun.status, 'completed')
   assert.equal(completedScriptRun.metadata.providerId, 'local')
   assert.equal(completedScriptRun.metadata.language, 'typescript')
+  assert.equal(completedScriptRun.metadata.runtimeCommand, 'node')
+  assert.deepEqual(completedScriptRun.metadata.runtimeArgs, ['script.mjs'])
+  assert.equal(completedScriptRun.metadata.policyTriggered, 'none')
 
   const pythonExecuted = await executeScriptWorkflowInSandbox({
     definition: python,
@@ -135,6 +138,8 @@ const run = async () => {
   assert.equal(pythonExecuted.status, 'completed')
   assert.match(pythonExecuted.stdout, /1/)
   assert.match(pythonExecuted.stdout, /2/)
+  assert.equal(pythonExecuted.metadata.runtimeCommand, 'python3')
+  assert.deepEqual(pythonExecuted.metadata.runtimeArgs, ['script.py'])
 
   const pythonScheduledExecuted = await executeScriptWorkflowInSandbox({
     definition: pythonScheduled,
@@ -272,6 +277,8 @@ const run = async () => {
   assert.equal(outputPolicyRun.status, 'failed')
   assert.equal(outputPolicyRun.errorCode, 'policy-violation')
   assert.match(outputPolicyRun.errorMessage, /exceeded 1024 bytes/)
+  assert.equal(outputPolicyRun.metadata.policyTriggered, 'output-size')
+  assert.equal(outputPolicyRun.metadata.totalOutputBytes > 1024, true)
 
   const sourcePolicySource = serializeWorkflowSource(
     baseFrontmatter('python'),
@@ -298,6 +305,7 @@ const run = async () => {
   assert.equal(sourcePolicyRun.status, 'failed')
   assert.equal(sourcePolicyRun.errorCode, 'policy-violation')
   assert.match(sourcePolicyRun.errorMessage, /source exceeded 256 bytes/)
+  assert.equal(sourcePolicyRun.metadata.policyTriggered, 'source-size')
 
   console.log('workflow language regression smoke checks passed')
 }

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -124,6 +124,8 @@ const run = async () => {
     triggerValue: 'manual'
   })
   assert.equal(completedScriptRun.status, 'completed')
+  assert.equal(completedScriptRun.metadata.providerId, 'local')
+  assert.equal(completedScriptRun.metadata.language, 'typescript')
 
   const pythonExecuted = await executeScriptWorkflowInSandbox({
     definition: python,
@@ -159,6 +161,47 @@ const run = async () => {
     'completed',
     'empty sandbox provider env should fall back to local provider'
   )
+
+  const envPolicySource = serializeWorkflowSource(
+    baseFrontmatter('python'),
+    'import os\nprint(os.environ.get("CORAZON_TEST_ALLOWED_ENV", "missing"))\nprint(os.environ.get("CORAZON_TEST_BLOCKED_ENV", "missing"))'
+  )
+  const envPolicyWorkflow = parseWorkflowSource({
+    fileSlug: 'python-env-policy',
+    filePath: '/tmp/python-env-policy.md',
+    source: envPolicySource,
+    updatedAt: Date.now()
+  })
+  const previousAllowlist = process.env.CORAZON_WORKFLOW_SCRIPT_ENV_ALLOWLIST
+  const previousAllowedEnv = process.env.CORAZON_TEST_ALLOWED_ENV
+  const previousBlockedEnv = process.env.CORAZON_TEST_BLOCKED_ENV
+  process.env.CORAZON_WORKFLOW_SCRIPT_ENV_ALLOWLIST = 'CORAZON_TEST_ALLOWED_ENV'
+  process.env.CORAZON_TEST_ALLOWED_ENV = 'allowed'
+  process.env.CORAZON_TEST_BLOCKED_ENV = 'blocked'
+  const envPolicyRun = await executeScriptWorkflowInSandbox({
+    definition: envPolicyWorkflow,
+    triggerType: 'workflow-dispatch',
+    triggerValue: 'manual'
+  })
+  if (typeof previousAllowlist === 'string') {
+    process.env.CORAZON_WORKFLOW_SCRIPT_ENV_ALLOWLIST = previousAllowlist
+  } else {
+    delete process.env.CORAZON_WORKFLOW_SCRIPT_ENV_ALLOWLIST
+  }
+  if (typeof previousAllowedEnv === 'string') {
+    process.env.CORAZON_TEST_ALLOWED_ENV = previousAllowedEnv
+  } else {
+    delete process.env.CORAZON_TEST_ALLOWED_ENV
+  }
+  if (typeof previousBlockedEnv === 'string') {
+    process.env.CORAZON_TEST_BLOCKED_ENV = previousBlockedEnv
+  } else {
+    delete process.env.CORAZON_TEST_BLOCKED_ENV
+  }
+  assert.equal(envPolicyRun.status, 'completed')
+  assert.match(envPolicyRun.stdout, /allowed/)
+  assert.match(envPolicyRun.stdout, /missing/)
+  assert.deepEqual(envPolicyRun.metadata.allowedEnvKeys, ['CORAZON_TEST_ALLOWED_ENV'])
 
   const failedScriptSource = serializeWorkflowSource(
     baseFrontmatter('typescript'),
@@ -203,6 +246,32 @@ const run = async () => {
   }
   assert.equal(timedOutScriptRun.status, 'failed')
   assert.equal(timedOutScriptRun.errorCode, 'execution-timeout')
+
+  const outputPolicySource = serializeWorkflowSource(
+    baseFrontmatter('python'),
+    'print("x" * 2000)'
+  )
+  const outputPolicyWorkflow = parseWorkflowSource({
+    fileSlug: 'python-output-policy',
+    filePath: '/tmp/python-output-policy.md',
+    source: outputPolicySource,
+    updatedAt: Date.now()
+  })
+  const previousMaxOutput = process.env.CORAZON_WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES
+  process.env.CORAZON_WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES = '1024'
+  const outputPolicyRun = await executeScriptWorkflowInSandbox({
+    definition: outputPolicyWorkflow,
+    triggerType: 'workflow-dispatch',
+    triggerValue: 'manual'
+  })
+  if (typeof previousMaxOutput === 'string') {
+    process.env.CORAZON_WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES = previousMaxOutput
+  } else {
+    delete process.env.CORAZON_WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES
+  }
+  assert.equal(outputPolicyRun.status, 'failed')
+  assert.equal(outputPolicyRun.errorCode, 'policy-violation')
+  assert.match(outputPolicyRun.errorMessage, /exceeded 1024 bytes/)
 
   console.log('workflow language regression smoke checks passed')
 }

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -120,6 +120,34 @@ const run = async () => {
   })
   assert.equal(completedScriptRun.status, 'completed')
 
+  const pythonExecuted = await executeScriptWorkflowInSandbox({
+    definition: python,
+    triggerType: 'workflow-dispatch',
+    triggerValue: 'manual'
+  })
+  assert.equal(pythonExecuted.status, 'completed')
+  assert.match(pythonExecuted.stdout, /1/)
+  assert.match(pythonExecuted.stdout, /2/)
+
+  const failedScriptSource = serializeWorkflowSource(
+    baseFrontmatter('typescript'),
+    'console.error("boom"); process.exit(7)'
+  )
+  const failedScriptWorkflow = parseWorkflowSource({
+    fileSlug: 'typescript-failure',
+    filePath: '/tmp/typescript-failure.md',
+    source: failedScriptSource,
+    updatedAt: Date.now()
+  })
+  const failedScriptRun = await executeScriptWorkflowInSandbox({
+    definition: failedScriptWorkflow,
+    triggerType: 'workflow-dispatch',
+    triggerValue: 'manual'
+  })
+  assert.equal(failedScriptRun.status, 'failed')
+  assert.equal(failedScriptRun.errorCode, 'execution-failed')
+  assert.equal(failedScriptRun.exitCode, 7)
+
   const timeoutSource = serializeWorkflowSource(
     baseFrontmatter('typescript'),
     'await new Promise(resolve => setTimeout(resolve, 120));\nconsole.log("done")'

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -150,6 +150,23 @@ const run = async () => {
   assert.equal(pythonScheduledExecuted.status, 'completed')
   assert.match(pythonScheduledExecuted.stdout, /scheduled python/)
 
+  const previousPythonBin = process.env.CORAZON_WORKFLOW_PYTHON_BIN
+  process.env.CORAZON_WORKFLOW_PYTHON_BIN = 'corazon-missing-python-bin'
+  const providerFailureRun = await executeScriptWorkflowInSandbox({
+    definition: python,
+    triggerType: 'workflow-dispatch',
+    triggerValue: 'manual'
+  })
+  if (typeof previousPythonBin === 'string') {
+    process.env.CORAZON_WORKFLOW_PYTHON_BIN = previousPythonBin
+  } else {
+    delete process.env.CORAZON_WORKFLOW_PYTHON_BIN
+  }
+  assert.equal(providerFailureRun.status, 'failed')
+  assert.equal(providerFailureRun.errorCode, 'provider-error')
+  assert.equal(providerFailureRun.metadata.failurePhase, 'execute')
+  assert.match(providerFailureRun.errorMessage, /Failed to start script runtime/)
+
   const previousProvider = process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER
   process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER = ''
   const pythonWithBlankProvider = await executeScriptWorkflowInSandbox({

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -60,20 +60,25 @@ const run = async () => {
     'script workflows should preserve code body except leading/trailing whitespace trim'
   )
 
-  assert.throws(
-    () => serializeWorkflowSource(
-      {
-        ...baseFrontmatter('python'),
-        on: {
-          'schedule': '*/5 * * * *',
-          'workflow-dispatch': false
-        }
-      },
-      'print("hi")'
-    ),
-    /Time triggers \("schedule", "interval", "rrule"\) currently support only markdown workflows\./,
-    'non-markdown workflows with time triggers must fail validation'
+  const pythonScheduledSource = serializeWorkflowSource(
+    {
+      ...baseFrontmatter('python'),
+      on: {
+        'schedule': '*/5 * * * *',
+        'workflow-dispatch': false
+      }
+    },
+    'print("scheduled python")'
   )
+  const pythonScheduled = parseWorkflowSource({
+    fileSlug: 'python-scheduled',
+    filePath: '/tmp/python-scheduled.md',
+    source: pythonScheduledSource,
+    updatedAt: Date.now()
+  })
+  assert.equal(pythonScheduled.isValid, true)
+  assert.equal(pythonScheduled.frontmatter.on.schedule, '*/5 * * * *')
+  assert.equal(pythonScheduled.frontmatter.on['workflow-dispatch'], false)
 
   const invalidLanguage = parseWorkflowSource({
     fileSlug: 'invalid-language',
@@ -128,6 +133,14 @@ const run = async () => {
   assert.equal(pythonExecuted.status, 'completed')
   assert.match(pythonExecuted.stdout, /1/)
   assert.match(pythonExecuted.stdout, /2/)
+
+  const pythonScheduledExecuted = await executeScriptWorkflowInSandbox({
+    definition: pythonScheduled,
+    triggerType: 'schedule',
+    triggerValue: '*/5 * * * *'
+  })
+  assert.equal(pythonScheduledExecuted.status, 'completed')
+  assert.match(pythonScheduledExecuted.stdout, /scheduled python/)
 
   const previousProvider = process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER
   process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER = ''

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { parseWorkflowSource, serializeWorkflowSource } from '../server/utils/workflow-definitions.ts'
+import { executeScriptWorkflowInSandbox } from '../server/utils/workflow-script-sandbox.ts'
 import type { WorkflowFrontmatter } from '../types/workflow.ts'
 
 const baseFrontmatter = (language: WorkflowFrontmatter['language']): WorkflowFrontmatter => ({
@@ -10,7 +11,7 @@ const baseFrontmatter = (language: WorkflowFrontmatter['language']): WorkflowFro
   skills: []
 })
 
-const run = () => {
+const run = async () => {
   const markdownSource = serializeWorkflowSource(
     {
       ...baseFrontmatter('markdown'),
@@ -112,7 +113,42 @@ const run = () => {
   assert.equal(typescript.frontmatter.on.interval, undefined)
   assert.equal(typescript.frontmatter.on.rrule, undefined)
 
+  const completedScriptRun = await executeScriptWorkflowInSandbox({
+    definition: typescript,
+    triggerType: 'workflow-dispatch',
+    triggerValue: 'manual'
+  })
+  assert.equal(completedScriptRun.status, 'completed')
+
+  const timeoutSource = serializeWorkflowSource(
+    baseFrontmatter('typescript'),
+    'await new Promise(resolve => setTimeout(resolve, 120));\nconsole.log("done")'
+  )
+  const timeoutWorkflow = parseWorkflowSource({
+    fileSlug: 'typescript-timeout',
+    filePath: '/tmp/typescript-timeout.md',
+    source: timeoutSource,
+    updatedAt: Date.now()
+  })
+  const previousTimeout = process.env.CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS
+  process.env.CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS = '50'
+  const timedOutScriptRun = await executeScriptWorkflowInSandbox({
+    definition: timeoutWorkflow,
+    triggerType: 'workflow-dispatch',
+    triggerValue: 'manual'
+  })
+  if (typeof previousTimeout === 'string') {
+    process.env.CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS = previousTimeout
+  } else {
+    delete process.env.CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS
+  }
+  assert.equal(timedOutScriptRun.status, 'failed')
+  assert.equal(timedOutScriptRun.errorCode, 'execution-timeout')
+
   console.log('workflow language regression smoke checks passed')
 }
 
-run()
+run().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -130,6 +130,7 @@ const run = async () => {
   assert.deepEqual(completedScriptRun.metadata.runtimeArgs, ['script.mjs'])
   assert.equal(completedScriptRun.metadata.policyTriggered, 'none')
   assert.equal(completedScriptRun.metadata.terminationScope, 'none')
+  assert.equal(completedScriptRun.metadata.executionDurationMs, completedScriptRun.durationMs)
 
   const pythonExecuted = await executeScriptWorkflowInSandbox({
     definition: python,
@@ -165,6 +166,7 @@ const run = async () => {
   assert.equal(providerFailureRun.status, 'failed')
   assert.equal(providerFailureRun.errorCode, 'provider-error')
   assert.equal(providerFailureRun.metadata.failurePhase, 'execute')
+  assert.equal(providerFailureRun.metadata.executionDurationMs, providerFailureRun.durationMs)
   assert.match(providerFailureRun.errorMessage, /Failed to start script runtime/)
 
   const previousProvider = process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER
@@ -300,6 +302,7 @@ const run = async () => {
   assert.equal(outputPolicyRun.errorCode, 'policy-violation')
   assert.match(outputPolicyRun.errorMessage, /exceeded 1024 bytes/)
   assert.equal(outputPolicyRun.metadata.policyTriggered, 'output-size')
+  assert.equal(outputPolicyRun.metadata.executionDurationMs, outputPolicyRun.durationMs)
   assert.equal(outputPolicyRun.metadata.totalOutputBytes > 1024, true)
   assert.equal(
     ['process-group', 'process'].includes(outputPolicyRun.metadata.terminationScope),
@@ -332,6 +335,7 @@ const run = async () => {
   assert.equal(sourcePolicyRun.errorCode, 'policy-violation')
   assert.match(sourcePolicyRun.errorMessage, /source exceeded 256 bytes/)
   assert.equal(sourcePolicyRun.metadata.policyTriggered, 'source-size')
+  assert.equal(sourcePolicyRun.metadata.executionDurationMs, sourcePolicyRun.durationMs)
 
   console.log('workflow language regression smoke checks passed')
 }

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -273,6 +273,32 @@ const run = async () => {
   assert.equal(outputPolicyRun.errorCode, 'policy-violation')
   assert.match(outputPolicyRun.errorMessage, /exceeded 1024 bytes/)
 
+  const sourcePolicySource = serializeWorkflowSource(
+    baseFrontmatter('python'),
+    `print("${'x'.repeat(400)}")`
+  )
+  const sourcePolicyWorkflow = parseWorkflowSource({
+    fileSlug: 'python-source-policy',
+    filePath: '/tmp/python-source-policy.md',
+    source: sourcePolicySource,
+    updatedAt: Date.now()
+  })
+  const previousMaxSource = process.env.CORAZON_WORKFLOW_SCRIPT_MAX_SOURCE_BYTES
+  process.env.CORAZON_WORKFLOW_SCRIPT_MAX_SOURCE_BYTES = '256'
+  const sourcePolicyRun = await executeScriptWorkflowInSandbox({
+    definition: sourcePolicyWorkflow,
+    triggerType: 'workflow-dispatch',
+    triggerValue: 'manual'
+  })
+  if (typeof previousMaxSource === 'string') {
+    process.env.CORAZON_WORKFLOW_SCRIPT_MAX_SOURCE_BYTES = previousMaxSource
+  } else {
+    delete process.env.CORAZON_WORKFLOW_SCRIPT_MAX_SOURCE_BYTES
+  }
+  assert.equal(sourcePolicyRun.status, 'failed')
+  assert.equal(sourcePolicyRun.errorCode, 'policy-violation')
+  assert.match(sourcePolicyRun.errorMessage, /source exceeded 256 bytes/)
+
   console.log('workflow language regression smoke checks passed')
 }
 

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -196,7 +196,11 @@ const run = async () => {
 
   const envPolicySource = serializeWorkflowSource(
     baseFrontmatter('python'),
-    'import os\nprint(os.environ.get("CORAZON_TEST_ALLOWED_ENV", "missing"))\nprint(os.environ.get("CORAZON_TEST_BLOCKED_ENV", "missing"))'
+    'import os\n'
+    + 'print(f"ALLOWED={os.environ.get(\'CORAZON_TEST_ALLOWED_ENV\', \'missing\')}")\n'
+    + 'print(f"BLOCKED={os.environ.get(\'CORAZON_TEST_BLOCKED_ENV\', \'missing\')}")\n'
+    + 'print(f"HOME={os.environ.get(\'HOME\', \'missing\')}")\n'
+    + 'print(f"TMPDIR={os.environ.get(\'TMPDIR\', \'missing\')}")'
   )
   const envPolicyWorkflow = parseWorkflowSource({
     fileSlug: 'python-env-policy',
@@ -231,8 +235,14 @@ const run = async () => {
     delete process.env.CORAZON_TEST_BLOCKED_ENV
   }
   assert.equal(envPolicyRun.status, 'completed')
-  assert.match(envPolicyRun.stdout, /allowed/)
-  assert.match(envPolicyRun.stdout, /missing/)
+  assert.match(envPolicyRun.stdout, /ALLOWED=allowed/)
+  assert.match(envPolicyRun.stdout, /BLOCKED=missing/)
+  const sandboxHome = envPolicyRun.stdout.match(/^HOME=(.+)$/m)?.[1] ?? null
+  const sandboxTmpDir = envPolicyRun.stdout.match(/^TMPDIR=(.+)$/m)?.[1] ?? null
+  assert.equal(typeof sandboxHome, 'string')
+  assert.equal(typeof sandboxTmpDir, 'string')
+  assert.equal(sandboxHome?.startsWith('/tmp/corazon-workflow-script-') ?? false, true)
+  assert.equal(sandboxTmpDir?.startsWith('/tmp/corazon-workflow-script-') ?? false, true)
   assert.deepEqual(envPolicyRun.metadata.allowedEnvKeys, ['CORAZON_TEST_ALLOWED_ENV'])
 
   const failedScriptSource = serializeWorkflowSource(

--- a/scripts/workflow-language-regression-smoke.ts
+++ b/scripts/workflow-language-regression-smoke.ts
@@ -130,6 +130,7 @@ const run = async () => {
   assert.deepEqual(completedScriptRun.metadata.runtimeArgs, ['script.mjs'])
   assert.equal(completedScriptRun.metadata.policyTriggered, 'none')
   assert.equal(completedScriptRun.metadata.terminationScope, 'none')
+  assert.equal(completedScriptRun.metadata.outputTruncated, false)
   assert.equal(completedScriptRun.metadata.executionDurationMs, completedScriptRun.durationMs)
 
   const pythonExecuted = await executeScriptWorkflowInSandbox({
@@ -302,6 +303,7 @@ const run = async () => {
   assert.equal(outputPolicyRun.errorCode, 'policy-violation')
   assert.match(outputPolicyRun.errorMessage, /exceeded 1024 bytes/)
   assert.equal(outputPolicyRun.metadata.policyTriggered, 'output-size')
+  assert.equal(outputPolicyRun.metadata.outputTruncated, true)
   assert.equal(outputPolicyRun.metadata.executionDurationMs, outputPolicyRun.durationMs)
   assert.equal(outputPolicyRun.metadata.totalOutputBytes > 1024, true)
   assert.equal(

--- a/server/api/workflows/[name]/run.post.ts
+++ b/server/api/workflows/[name]/run.post.ts
@@ -28,7 +28,20 @@ export default defineEventHandler(async (event) => {
   }
 
   initializeWorkflowRunner()
-  const run = startWorkflowBySlug(definition.fileSlug, 'workflow-dispatch', 'manual')
+  let run
+  try {
+    run = startWorkflowBySlug(definition.fileSlug, 'workflow-dispatch', 'manual')
+  } catch (error) {
+    if (isUnsupportedWorkflowLanguageError(error)) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: error instanceof Error
+          ? error.message
+          : 'This workflow language is not executable yet.'
+      })
+    }
+    throw error
+  }
 
   return { run }
 })

--- a/server/utils/codex-client/native-tools.ts
+++ b/server/utils/codex-client/native-tools.ts
@@ -355,6 +355,17 @@ const normalizeWorkflowLanguage = (value: unknown, fallback: WorkflowLanguage = 
   return normalized as WorkflowLanguage
 }
 
+const normalizeWorkflowInstructionForLanguage = (instruction: unknown, language: WorkflowLanguage): string => {
+  const source = asString(instruction)
+  if (!source) {
+    return ''
+  }
+  if (language === 'markdown') {
+    return normalizeWorkflowInstructionText(source)
+  }
+  return source.replace(/\r\n/g, '\n').trim()
+}
+
 const listAvailableSkills = () => {
   const candidates: string[] = []
   const codexHome = asString(process.env.CODEX_HOME)
@@ -586,7 +597,8 @@ const handleWorkflowInspect = (args: Record<string, unknown>) => {
 }
 
 const handleWorkflowCreate = (args: Record<string, unknown>) => {
-  const instruction = normalizeWorkflowInstructionText(asString(args.instruction))
+  const language = normalizeWorkflowLanguage(args.language, 'markdown')
+  const instruction = normalizeWorkflowInstructionForLanguage(args.instruction, language)
   if (!instruction) {
     throw new Error('create requires "instruction".')
   }
@@ -595,7 +607,7 @@ const handleWorkflowCreate = (args: Record<string, unknown>) => {
   const frontmatter = buildWorkflowFrontmatter({
     name: asString(args.name) || instruction,
     description: asString(args.description) || instruction,
-    language: normalizeWorkflowLanguage(args.language, 'markdown'),
+    language,
     triggerType,
     triggerValue,
     workflowDispatch: asBoolean(args.workflowDispatch, true),
@@ -664,17 +676,18 @@ const handleWorkflowUpdate = (args: Record<string, unknown>) => {
   const nextSkills = [...new Set([...nextSkillsBase, ...addSkills])]
     .filter(item => !removeSkillSet.has(item))
 
+  const language = normalizeWorkflowLanguage(args.language, target.frontmatter.language)
   const frontmatter = buildWorkflowFrontmatter({
     name: asString(args.name) || target.frontmatter.name,
     description: asString(args.description) || target.frontmatter.description,
-    language: normalizeWorkflowLanguage(args.language, target.frontmatter.language),
+    language,
     triggerType,
     triggerValue,
     workflowDispatch: asBoolean(args.workflowDispatch, target.frontmatter.on['workflow-dispatch'] === true),
     skills: nextSkills
   })
 
-  const instruction = normalizeWorkflowInstructionText(asString(args.instruction)) || target.instruction
+  const instruction = normalizeWorkflowInstructionForLanguage(args.instruction, language) || target.instruction
   const updated = writeWorkflowDefinition(target.fileSlug, frontmatter, instruction)
   reloadWorkflowScheduler()
 

--- a/server/utils/codex-client/native-tools.ts
+++ b/server/utils/codex-client/native-tools.ts
@@ -6,7 +6,7 @@ import type { DynamicToolCallOutputContentItem } from '@@/types/codex-app-server
 import type { DynamicToolCallResponse } from '@@/types/codex-app-server/v2/DynamicToolCallResponse'
 import type { DynamicToolSpec } from '@@/types/codex-app-server/v2/DynamicToolSpec'
 import type { JsonValue } from '@@/types/codex-app-server/serde_json/JsonValue'
-import type { WorkflowDefinition, WorkflowFrontmatter } from '@@/types/workflow'
+import type { WorkflowDefinition, WorkflowFrontmatter, WorkflowLanguage } from '@@/types/workflow'
 import { rememberText, searchMemories } from '../memory.ts'
 import {
   deleteWorkflowDefinitionBySlug,
@@ -42,6 +42,7 @@ type ParsedWorkflowDraft = {
     name: string
     description: string
     instruction: string
+    language: WorkflowLanguage
     triggerType: WorkflowTriggerType | null
     triggerValue: string | null
     workflowDispatch: boolean
@@ -57,6 +58,7 @@ const DEFAULT_MEMORY_SECTION = 'Facts'
 const DEFAULT_WORKFLOW_NAME = 'Task Workflow'
 const WORKFLOW_DESCRIPTION_MAX_LENGTH = 180
 const WORKFLOW_NAME_WORD_PATTERN = /^[A-Za-z]+$/
+const WORKFLOW_LANGUAGES = new Set<WorkflowLanguage>(['markdown', 'typescript', 'python'])
 const WORKFLOW_COMMANDS = new Set([
   'list',
   'create',
@@ -102,6 +104,10 @@ const MANAGE_WORKFLOWS_TOOL_SCHEMA: JsonValue = {
     instruction: { type: 'string' },
     name: { type: 'string' },
     description: { type: 'string' },
+    language: {
+      type: 'string',
+      enum: ['markdown', 'typescript', 'python']
+    },
     schedule: { type: 'string' },
     interval: { type: 'string' },
     rrule: { type: 'string' },
@@ -273,6 +279,7 @@ const toWorkflowSummary = (workflow: WorkflowDefinition) => ({
   parseError: workflow.parseError,
   name: workflow.frontmatter.name,
   description: workflow.frontmatter.description,
+  language: workflow.frontmatter.language,
   schedule: workflow.frontmatter.on.schedule ?? null,
   interval: workflow.frontmatter.on.interval ?? null,
   rrule: workflow.frontmatter.on.rrule ?? null,
@@ -337,6 +344,17 @@ const resolveValidatedTrigger = (
   return { triggerType: null, triggerValue: null }
 }
 
+const normalizeWorkflowLanguage = (value: unknown, fallback: WorkflowLanguage = 'markdown'): WorkflowLanguage => {
+  const normalized = asString(value).toLowerCase()
+  if (!normalized) {
+    return fallback
+  }
+  if (!WORKFLOW_LANGUAGES.has(normalized as WorkflowLanguage)) {
+    throw new Error('Workflow language must be one of: markdown, typescript, python.')
+  }
+  return normalized as WorkflowLanguage
+}
+
 const listAvailableSkills = () => {
   const candidates: string[] = []
   const codexHome = asString(process.env.CODEX_HOME)
@@ -394,6 +412,7 @@ const parseWorkflowDraftFromText = async (text: string): Promise<ParsedWorkflowD
           instruction: ensureDetailedWorkflowInstruction(
             asString(inferred.enhancedInstruction) || source
           ),
+          language: 'markdown',
           triggerType: resolvedTrigger.triggerType,
           triggerValue: resolvedTrigger.triggerValue,
           workflowDispatch: true,
@@ -412,6 +431,7 @@ const parseWorkflowDraftFromText = async (text: string): Promise<ParsedWorkflowD
       name: normalizeWorkflowName(source),
       description: normalizeWorkflowDescription(source),
       instruction: ensureDetailedWorkflowInstruction(source),
+      language: 'markdown',
       triggerType: null,
       triggerValue: null,
       workflowDispatch: true,
@@ -423,6 +443,7 @@ const parseWorkflowDraftFromText = async (text: string): Promise<ParsedWorkflowD
 const buildWorkflowFrontmatter = (input: {
   name: string
   description: string
+  language: WorkflowLanguage
   triggerType: WorkflowTriggerType | null
   triggerValue: string | null
   workflowDispatch: boolean
@@ -430,6 +451,7 @@ const buildWorkflowFrontmatter = (input: {
 }): WorkflowFrontmatter => ({
   name: normalizeWorkflowName(input.name),
   description: normalizeWorkflowDescription(input.description),
+  language: input.language,
   on: {
     ...(input.triggerType === 'schedule' && input.triggerValue
       ? { schedule: input.triggerValue }
@@ -573,6 +595,7 @@ const handleWorkflowCreate = (args: Record<string, unknown>) => {
   const frontmatter = buildWorkflowFrontmatter({
     name: asString(args.name) || instruction,
     description: asString(args.description) || instruction,
+    language: normalizeWorkflowLanguage(args.language, 'markdown'),
     triggerType,
     triggerValue,
     workflowDispatch: asBoolean(args.workflowDispatch, true),
@@ -644,6 +667,7 @@ const handleWorkflowUpdate = (args: Record<string, unknown>) => {
   const frontmatter = buildWorkflowFrontmatter({
     name: asString(args.name) || target.frontmatter.name,
     description: asString(args.description) || target.frontmatter.description,
+    language: normalizeWorkflowLanguage(args.language, target.frontmatter.language),
     triggerType,
     triggerValue,
     workflowDispatch: asBoolean(args.workflowDispatch, target.frontmatter.on['workflow-dispatch'] === true),
@@ -744,6 +768,7 @@ const handleWorkflowApplyText = async (args: Record<string, unknown>) => {
       name: parsed.draft.name,
       description: parsed.draft.description,
       instruction: parsed.draft.instruction,
+      language: parsed.draft.language,
       schedule: parsed.draft.triggerType === 'schedule' ? parsed.draft.triggerValue ?? '' : '',
       interval: parsed.draft.triggerType === 'interval' ? parsed.draft.triggerValue ?? '' : '',
       rrule: parsed.draft.triggerType === 'rrule' ? parsed.draft.triggerValue ?? '' : '',
@@ -762,6 +787,7 @@ const handleWorkflowApplyText = async (args: Record<string, unknown>) => {
     fileSlug: asString(args.fileSlug),
     name: parsed.draft.name,
     description: parsed.draft.description,
+    language: parsed.draft.language,
     schedule: parsed.draft.triggerType === 'schedule' ? parsed.draft.triggerValue ?? '' : '',
     interval: parsed.draft.triggerType === 'interval' ? parsed.draft.triggerValue ?? '' : '',
     rrule: parsed.draft.triggerType === 'rrule' ? parsed.draft.triggerValue ?? '' : '',

--- a/server/utils/codex-client/native-tools.ts
+++ b/server/utils/codex-client/native-tools.ts
@@ -801,7 +801,7 @@ const handleWorkflowApplyText = async (args: Record<string, unknown>) => {
     fileSlug: asString(args.fileSlug),
     name: parsed.draft.name,
     description: parsed.draft.description,
-    language: parsed.draft.language,
+    language: explicitLanguage || parsed.draft.language,
     schedule: parsed.draft.triggerType === 'schedule' ? parsed.draft.triggerValue ?? '' : '',
     interval: parsed.draft.triggerType === 'interval' ? parsed.draft.triggerValue ?? '' : '',
     rrule: parsed.draft.triggerType === 'rrule' ? parsed.draft.triggerValue ?? '' : '',

--- a/server/utils/codex-client/native-tools.ts
+++ b/server/utils/codex-client/native-tools.ts
@@ -769,6 +769,7 @@ const handleWorkflowApplyText = async (args: Record<string, unknown>) => {
   const resolvedMode = requestedMode === 'auto'
     ? (hasTarget ? 'update' : 'create')
     : requestedMode
+  const explicitLanguage = asString(args.language)
 
   if (resolvedMode === 'update') {
     if (!hasTarget) {
@@ -781,7 +782,7 @@ const handleWorkflowApplyText = async (args: Record<string, unknown>) => {
       name: parsed.draft.name,
       description: parsed.draft.description,
       instruction: parsed.draft.instruction,
-      language: parsed.draft.language,
+      language: explicitLanguage,
       schedule: parsed.draft.triggerType === 'schedule' ? parsed.draft.triggerValue ?? '' : '',
       interval: parsed.draft.triggerType === 'interval' ? parsed.draft.triggerValue ?? '' : '',
       rrule: parsed.draft.triggerType === 'rrule' ? parsed.draft.triggerValue ?? '' : '',

--- a/server/utils/db.ts
+++ b/server/utils/db.ts
@@ -121,6 +121,7 @@ type WorkflowRunRow = {
   session_thread_id: string | null
   session_file_path: string | null
   error_message: string | null
+  metadata_json: string | null
 }
 
 type TelegramTransportStateRow = {
@@ -286,7 +287,8 @@ const getDb = () => {
       total_output_tokens INTEGER NOT NULL DEFAULT 0,
       session_thread_id TEXT,
       session_file_path TEXT,
-      error_message TEXT
+      error_message TEXT,
+      metadata_json TEXT
     );
 
     CREATE TABLE IF NOT EXISTS telegram_transport_state (
@@ -356,6 +358,9 @@ const getDb = () => {
   const telegramSessionColumns = db.prepare('PRAGMA table_info(telegram_sessions)').all() as { name: string }[]
   const hasTelegramSessionColumn = (name: string) =>
     telegramSessionColumns.some(column => column.name === name)
+  const workflowRunColumns = db.prepare('PRAGMA table_info(runs)').all() as { name: string }[]
+  const hasWorkflowRunColumn = (name: string) =>
+    workflowRunColumns.some(column => column.name === name)
 
   if (!hasColumn('model')) {
     db.exec('ALTER TABLE threads ADD COLUMN model TEXT')
@@ -419,6 +424,10 @@ const getDb = () => {
 
   if (!hasTelegramSessionColumn('resume_confidence')) {
     db.exec('ALTER TABLE telegram_sessions ADD COLUMN resume_confidence REAL')
+  }
+
+  if (!hasWorkflowRunColumn('metadata_json')) {
+    db.exec('ALTER TABLE runs ADD COLUMN metadata_json TEXT')
   }
 
   return db
@@ -1728,7 +1737,19 @@ const toWorkflowRunSummary = (row: WorkflowRunRow): WorkflowRunSummary => ({
   totalOutputTokens: row.total_output_tokens,
   sessionThreadId: row.session_thread_id,
   sessionFilePath: row.session_file_path,
-  errorMessage: row.error_message
+  errorMessage: row.error_message,
+  metadata: (() => {
+    if (!row.metadata_json || row.metadata_json.trim() === '') {
+      return null
+    }
+
+    try {
+      const parsed = JSON.parse(row.metadata_json) as unknown
+      return (parsed && typeof parsed === 'object') ? parsed as Record<string, unknown> : null
+    } catch {
+      return null
+    }
+  })()
 })
 
 export const createWorkflowRun = (input: {
@@ -1794,9 +1815,11 @@ export const completeWorkflowRun = (input: {
   sessionThreadId?: string | null
   sessionFilePath?: string | null
   errorMessage?: string | null
+  metadata?: Record<string, unknown> | null
 }) => {
   const database = getDb()
   const completedAt = input.completedAt ?? Date.now()
+  const metadataJson = JSON.stringify(input.metadata ?? null)
 
   database
     .prepare(
@@ -1810,7 +1833,8 @@ export const completeWorkflowRun = (input: {
         total_output_tokens = ?,
         session_thread_id = COALESCE(?, session_thread_id),
         session_file_path = COALESCE(?, session_file_path),
-        error_message = ?
+        error_message = ?,
+        metadata_json = ?
       WHERE id = ?
     `
     )
@@ -1823,6 +1847,7 @@ export const completeWorkflowRun = (input: {
       input.sessionThreadId ?? null,
       input.sessionFilePath ?? null,
       input.errorMessage ?? null,
+      metadataJson,
       input.runId
     )
 }
@@ -1874,7 +1899,8 @@ export const getWorkflowRunById = (runId: string): WorkflowRunSummary | null => 
         total_output_tokens,
         session_thread_id,
         session_file_path,
-        error_message
+        error_message,
+        metadata_json
       FROM runs
       WHERE id = ?
     `
@@ -1915,7 +1941,8 @@ export const loadWorkflowRunsPageBySlug = (
         total_output_tokens,
         session_thread_id,
         session_file_path,
-        error_message
+        error_message,
+        metadata_json
       FROM runs
       WHERE workflow_file_slug = ?
       ORDER BY started_at DESC, id DESC

--- a/server/utils/workflow-definitions.ts
+++ b/server/utils/workflow-definitions.ts
@@ -404,10 +404,6 @@ const validateWorkflowRules = (
     return 'Frontmatter "language" must be one of: markdown, typescript, python.'
   }
 
-  if (language !== 'markdown' && timeTriggerCount > 0) {
-    return 'Time triggers ("schedule", "interval", "rrule") currently support only markdown workflows. Use "workflow-dispatch" for typescript/python until script runners are available.'
-  }
-
   if (!instruction.trim()) {
     return 'Workflow instruction body is required.'
   }

--- a/server/utils/workflow-definitions.ts
+++ b/server/utils/workflow-definitions.ts
@@ -404,6 +404,10 @@ const validateWorkflowRules = (
     return 'Frontmatter "language" must be one of: markdown, typescript, python.'
   }
 
+  if (language !== 'markdown' && timeTriggerCount > 0) {
+    return 'Time triggers ("schedule", "interval", "rrule") currently support only markdown workflows. Use "workflow-dispatch" for typescript/python until script runners are available.'
+  }
+
   if (!instruction.trim()) {
     return 'Workflow instruction body is required.'
   }

--- a/server/utils/workflow-definitions.ts
+++ b/server/utils/workflow-definitions.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { Cron } from 'croner'
 import rrule from 'rrule'
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
-import type { WorkflowDefinition, WorkflowFrontmatter, WorkflowTriggerConfig } from '@@/types/workflow'
+import type { WorkflowDefinition, WorkflowFrontmatter, WorkflowLanguage, WorkflowTriggerConfig } from '@@/types/workflow'
 import { resolveCorazonRootDir } from './agent-home.ts'
 
 const { rrulestr } = rrule
@@ -11,6 +11,8 @@ const { rrulestr } = rrule
 const WORKFLOWS_DIRECTORY = 'workflows'
 const WORKFLOW_FILE_EXTENSION = '.md'
 const INTERVAL_PATTERN = /^([1-9][0-9]*)(s|m|h)$/
+const WORKFLOW_LANGUAGES = new Set<WorkflowLanguage>(['markdown', 'typescript', 'python'])
+const DEFAULT_WORKFLOW_LANGUAGE: WorkflowLanguage = 'markdown'
 const WORKFLOW_NAME_PATTERN = /^[A-Za-z]+(?: [A-Za-z]+){1,2}$/
 const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/
 const WORKFLOW_CADENCE_CORE = String.raw`(?:매\s*\d+\s*(?:초|분|시간|일|주|개월|달|월|년)마다|(?:\d+\s*(?:초|분|시간|일|주|개월|달|월|년))(?:에)?\s*(?:한\s*번|한번)|매(?:일|주|월|년)|every\s+\d+\s*(?:seconds?|minutes?|hours?|days?|weeks?|months?)|every\s+(?:second|minute|hour|day|week|month)s?|daily|weekly|monthly|hourly)`
@@ -89,6 +91,7 @@ const createInvalidWorkflow = (input: {
   frontmatter: {
     name: input.fileSlug,
     description: '',
+    language: DEFAULT_WORKFLOW_LANGUAGE,
     on: { 'workflow-dispatch': true },
     skills: []
   },
@@ -120,6 +123,20 @@ const normalizeSkills = (value: unknown) => {
     .filter(Boolean)
 
   return [...new Set(normalized)]
+}
+
+const normalizeWorkflowLanguage = (value: unknown): WorkflowLanguage | null => {
+  if (value == null) {
+    return DEFAULT_WORKFLOW_LANGUAGE
+  }
+  if (typeof value !== 'string') {
+    return null
+  }
+  const normalized = value.trim().toLowerCase()
+  if (!WORKFLOW_LANGUAGES.has(normalized as WorkflowLanguage)) {
+    return null
+  }
+  return normalized as WorkflowLanguage
 }
 
 const sanitizeWorkflowInstructionSentence = (value: string) => {
@@ -360,6 +377,7 @@ const validateWorkflowRules = (
   const interval = frontmatter.on.interval?.trim()
   const rrule = frontmatter.on.rrule?.trim()
   const dispatch = frontmatter.on['workflow-dispatch'] === true
+  const language = frontmatter.language
 
   const timeTriggerCount = [schedule, interval, rrule].filter(Boolean).length
   if (timeTriggerCount > 1) {
@@ -382,11 +400,15 @@ const validateWorkflowRules = (
     return 'At least one trigger must be configured. Enable "workflow-dispatch" when no time trigger exists.'
   }
 
+  if (!WORKFLOW_LANGUAGES.has(language)) {
+    return 'Frontmatter "language" must be one of: markdown, typescript, python.'
+  }
+
   if (!instruction.trim()) {
     return 'Workflow instruction body is required.'
   }
 
-  if (options.requireDetailedInstruction) {
+  if (options.requireDetailedInstruction && language === 'markdown') {
     const instructionDetailError = getWorkflowInstructionDetailError(instruction)
     if (instructionDetailError) {
       return instructionDetailError
@@ -404,16 +426,18 @@ export const normalizeWorkflowFrontmatter = (value: unknown): WorkflowFrontmatte
 
   const name = typeof record.name === 'string' ? record.name.trim() : ''
   const description = typeof record.description === 'string' ? record.description.trim() : ''
+  const language = normalizeWorkflowLanguage(record.language)
   const on = normalizeTriggerConfig(record.on)
   const skills = normalizeSkills(record.skills)
 
-  if (!name || !description || !on || !skills) {
+  if (!name || !description || !language || !on || !skills) {
     return null
   }
 
   return {
     name,
     description,
+    language,
     on,
     skills
   }
@@ -530,6 +554,7 @@ export const serializeWorkflowSource = (
   const frontmatter: WorkflowFrontmatter = {
     name: frontmatterInput.name.trim(),
     description: frontmatterInput.description.trim(),
+    language: normalizeWorkflowLanguage(frontmatterInput.language) ?? DEFAULT_WORKFLOW_LANGUAGE,
     on: {
       'schedule': frontmatterInput.on.schedule?.trim() || undefined,
       'interval': frontmatterInput.on.interval?.trim() || undefined,
@@ -539,7 +564,10 @@ export const serializeWorkflowSource = (
     skills: [...new Set(frontmatterInput.skills.map(item => item.trim()).filter(Boolean))]
   }
 
-  const instruction = ensureDetailedWorkflowInstruction(instructionInput)
+  const normalizedInstruction = normalizeWorkflowInstructionText(instructionInput)
+  const instruction = frontmatter.language === 'markdown'
+    ? ensureDetailedWorkflowInstruction(normalizedInstruction)
+    : instructionInput.replace(/\r\n/g, '\n').trim()
   const validationError = validateWorkflowRules(frontmatter, instruction, {
     requireDetailedInstruction: true
   })
@@ -550,6 +578,7 @@ export const serializeWorkflowSource = (
   const yamlValue = stringifyYaml({
     name: frontmatter.name,
     description: frontmatter.description,
+    language: frontmatter.language,
     on: frontmatter.on,
     skills: frontmatter.skills
   }).trimEnd()
@@ -589,7 +618,7 @@ export const parseWorkflowSource = (input: {
   if (!frontmatter) {
     return createInvalidWorkflow({
       ...input,
-      parseError: 'Frontmatter must include name, description, on, skills.'
+      parseError: 'Frontmatter must include name, description, language, on, skills.'
     })
   }
 

--- a/server/utils/workflow-request.ts
+++ b/server/utils/workflow-request.ts
@@ -27,12 +27,17 @@ const asStringArray = (value: unknown) => {
 }
 
 const normalizeTriggerConfig = (input: {
+  language: WorkflowLanguage
   triggerType: WorkflowUpsertRequest['triggerType']
   triggerValue: string | null
   workflowDispatch: boolean
 }): WorkflowTriggerConfig => {
   const on: WorkflowTriggerConfig = {
     'workflow-dispatch': input.workflowDispatch
+  }
+
+  if (input.language !== 'markdown' && input.triggerType) {
+    throw new Error('Only markdown workflows can use schedule, interval, or rrule triggers.')
   }
 
   if (input.triggerType === 'schedule') {
@@ -110,6 +115,7 @@ export const parseWorkflowUpsertRequest = (body: unknown) => {
     description,
     language,
     on: normalizeTriggerConfig({
+      language,
       triggerType,
       triggerValue,
       workflowDispatch

--- a/server/utils/workflow-request.ts
+++ b/server/utils/workflow-request.ts
@@ -36,10 +36,6 @@ const normalizeTriggerConfig = (input: {
     'workflow-dispatch': input.workflowDispatch
   }
 
-  if (input.language !== 'markdown' && input.triggerType) {
-    throw new Error('Only markdown workflows can use schedule, interval, or rrule triggers.')
-  }
-
   if (input.triggerType === 'schedule') {
     if (!input.triggerValue) {
       throw new Error('Schedule value is required.')

--- a/server/utils/workflow-request.ts
+++ b/server/utils/workflow-request.ts
@@ -1,6 +1,18 @@
-import type { WorkflowFrontmatter, WorkflowTriggerConfig, WorkflowUpsertRequest } from '@@/types/workflow'
+import type { WorkflowFrontmatter, WorkflowLanguage, WorkflowTriggerConfig, WorkflowUpsertRequest } from '@@/types/workflow'
 
 const WORKFLOW_NAME_PATTERN = /^[A-Za-z]+(?: [A-Za-z]+){1,2}$/
+const WORKFLOW_LANGUAGES = new Set<WorkflowLanguage>(['markdown', 'typescript', 'python'])
+
+const normalizeLanguage = (value: unknown): WorkflowLanguage => {
+  if (typeof value !== 'string' || !value.trim()) {
+    return 'markdown'
+  }
+  const normalized = value.trim().toLowerCase()
+  if (!WORKFLOW_LANGUAGES.has(normalized as WorkflowLanguage)) {
+    throw new Error('Workflow language must be one of: markdown, typescript, python.')
+  }
+  return normalized as WorkflowLanguage
+}
 
 const asString = (value: unknown) => typeof value === 'string' ? value.trim() : ''
 
@@ -68,7 +80,11 @@ export const parseWorkflowUpsertRequest = (body: unknown) => {
 
   const name = asString(raw.name)
   const description = asString(raw.description)
-  const instruction = normalizeWorkflowInstructionText(asString(raw.instruction))
+  const language = normalizeLanguage(raw.language)
+  const instructionInput = asString(raw.instruction)
+  const instruction = language === 'markdown'
+    ? normalizeWorkflowInstructionText(instructionInput)
+    : instructionInput
   const skills = asStringArray(raw.skills)
   const triggerType = raw.triggerType === 'schedule' || raw.triggerType === 'interval' || raw.triggerType === 'rrule'
     ? raw.triggerType
@@ -92,6 +108,7 @@ export const parseWorkflowUpsertRequest = (body: unknown) => {
   const frontmatter: WorkflowFrontmatter = {
     name,
     description,
+    language,
     on: normalizeTriggerConfig({
       triggerType,
       triggerValue,

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -101,6 +101,16 @@ const shouldApplySelfEvolutionNoOpCommentPolicy = (definition: WorkflowDefinitio
   definition.fileSlug === 'corazon-self-evolution'
   || definition.frontmatter.name.trim().toLowerCase() === 'corazon self evolution'
 
+const ensureRunnableWorkflowLanguage = (definition: WorkflowDefinition) => {
+  if (definition.frontmatter.language === 'markdown') {
+    return
+  }
+  throw new Error(
+    `Workflow language "${definition.frontmatter.language}" is defined but not executable yet. `
+    + 'Only "markdown" workflows can run until the sandboxed script runner lands.'
+  )
+}
+
 const buildRunContextPrompt = (
   definition: WorkflowDefinition,
   triggerType: WorkflowTriggerType,
@@ -139,6 +149,7 @@ const buildRunContextPrompt = (
     '<run-context>',
     `workflow_name: ${definition.frontmatter.name}`,
     `workflow_description: ${definition.frontmatter.description}`,
+    `workflow_language: ${definition.frontmatter.language}`,
     `workflow_file: workflows/${definition.fileSlug}.md`,
     `allowed_skills: ${allowedSkills}`,
     `working_directory: ${process.cwd()}`,
@@ -371,6 +382,7 @@ export const executeWorkflowRun = async (
   if (!definition.isValid) {
     throw new Error(definition.parseError ?? 'Invalid workflow definition.')
   }
+  ensureRunnableWorkflowLanguage(definition)
 
   const runningSummary = createRunningWorkflowRun(definition, triggerType, triggerValue)
   return finalizeWorkflowRunExecution({
@@ -388,6 +400,7 @@ export const startWorkflowRun = (
   if (!definition.isValid) {
     throw new Error(definition.parseError ?? 'Invalid workflow definition.')
   }
+  ensureRunnableWorkflowLanguage(definition)
 
   const runningSummary = createRunningWorkflowRun(definition, triggerType, triggerValue)
   void finalizeWorkflowRunExecution({

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -201,9 +201,14 @@ const collectRunCompletionData = async (
     })
     if (result.status === 'failed') {
       const stderr = result.stderr.trim()
+      const metadataSummary
+        = `sandbox(provider=${result.metadata.providerId}, language=${result.metadata.language},`
+          + ` trigger=${result.metadata.triggerType}, timeoutMs=${result.metadata.timeoutMs},`
+          + ` maxOutputBytes=${result.metadata.maxOutputBytes},`
+          + ` allowEnv=${result.metadata.allowedEnvKeys.join(',') || '(none)'})`
       const failureDetail = stderr.length > 0
-        ? `${result.errorMessage}\n\nstderr:\n${stderr}`
-        : result.errorMessage
+        ? `${result.errorMessage}\n${metadataSummary}\n\nstderr:\n${stderr}`
+        : `${result.errorMessage}\n${metadataSummary}`
       throw new Error(failureDetail)
     }
 

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -213,6 +213,7 @@ const collectRunCompletionData = async (
           + ` signal=${result.metadata.terminationSignal ?? '(none)'},`
           + ` terminationScope=${result.metadata.terminationScope},`
           + ` policy=${result.metadata.policyTriggered},`
+          + ` failurePhase=${result.metadata.failurePhase},`
           + ` allowEnv=${result.metadata.allowedEnvKeys.join(',') || '(none)'})`
       const failureDetail = stderr.length > 0
         ? `${result.errorMessage}\n${metadataSummary}\n\nstderr:\n${stderr}`

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -212,6 +212,7 @@ const collectRunCompletionData = async (
       const metadataSummary
         = `sandbox(provider=${result.metadata.providerId}, language=${result.metadata.language},`
           + ` trigger=${result.metadata.triggerType}, timeoutMs=${result.metadata.timeoutMs},`
+          + ` durationMs=${result.metadata.executionDurationMs},`
           + ` maxOutputBytes=${result.metadata.maxOutputBytes},`
           + ` sourceBytes=${result.metadata.sourceBytes}/${result.metadata.maxSourceBytes},`
           + ` runtime=${result.metadata.runtimeCommand ?? '(none)'}`

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -101,14 +101,20 @@ const shouldApplySelfEvolutionNoOpCommentPolicy = (definition: WorkflowDefinitio
   definition.fileSlug === 'corazon-self-evolution'
   || definition.frontmatter.name.trim().toLowerCase() === 'corazon self evolution'
 
+const buildUnsupportedWorkflowLanguageMessage = (language: string) =>
+  `Workflow language "${language}" is defined but not executable yet. `
+  + 'Only "markdown" workflows can run until the sandboxed script runner lands.'
+
+export const isUnsupportedWorkflowLanguageError = (error: unknown) =>
+  error instanceof Error
+  && error.message.includes('is defined but not executable yet.')
+  && error.message.includes('Only "markdown" workflows can run until the sandboxed script runner lands.')
+
 const ensureRunnableWorkflowLanguage = (definition: WorkflowDefinition) => {
   if (definition.frontmatter.language === 'markdown') {
     return
   }
-  throw new Error(
-    `Workflow language "${definition.frontmatter.language}" is defined but not executable yet. `
-    + 'Only "markdown" workflows can run until the sandboxed script runner lands.'
-  )
+  throw new Error(buildUnsupportedWorkflowLanguageMessage(definition.frontmatter.language))
 }
 
 const buildRunContextPrompt = (

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -219,6 +219,7 @@ const collectRunCompletionData = async (
           + (result.metadata.runtimeArgs.length > 0 ? ` ${result.metadata.runtimeArgs.join(' ')}` : '')
           + `, outputBytes=${result.metadata.stdoutBytes + result.metadata.stderrBytes}`
           + ` (stdout=${result.metadata.stdoutBytes}, stderr=${result.metadata.stderrBytes}),`
+          + ` outputTruncated=${result.metadata.outputTruncated},`
           + ` signal=${result.metadata.terminationSignal ?? '(none)'},`
           + ` terminationScope=${result.metadata.terminationScope},`
           + ` policy=${result.metadata.policyTriggered},`

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -199,7 +199,15 @@ const collectRunCompletionData = async (
       triggerType,
       triggerValue
     })
+    const runMetadata: Record<string, unknown> = {
+      sandbox: result.metadata
+    }
+
     if (result.status === 'failed') {
+      runMetadata.errorCode = result.errorCode
+      if (typeof result.exitCode === 'number') {
+        runMetadata.exitCode = result.exitCode
+      }
       const stderr = result.stderr.trim()
       const metadataSummary
         = `sandbox(provider=${result.metadata.providerId}, language=${result.metadata.language},`
@@ -218,7 +226,17 @@ const collectRunCompletionData = async (
       const failureDetail = stderr.length > 0
         ? `${result.errorMessage}\n${metadataSummary}\n\nstderr:\n${stderr}`
         : `${result.errorMessage}\n${metadataSummary}`
-      throw new Error(failureDetail)
+
+      completeWorkflowRun({
+        runId,
+        status: 'failed',
+        totalInputTokens: 0,
+        totalCachedInputTokens: 0,
+        totalOutputTokens: 0,
+        errorMessage: failureDetail,
+        metadata: runMetadata
+      })
+      return
     }
 
     completeWorkflowRun({
@@ -226,7 +244,8 @@ const collectRunCompletionData = async (
       status: 'completed',
       totalInputTokens: 0,
       totalCachedInputTokens: 0,
-      totalOutputTokens: 0
+      totalOutputTokens: 0,
+      metadata: runMetadata
     })
     return
   }

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -213,6 +213,9 @@ const collectRunCompletionData = async (
         = `sandbox(provider=${result.metadata.providerId}, language=${result.metadata.language},`
           + ` trigger=${result.metadata.triggerType}, timeoutMs=${result.metadata.timeoutMs},`
           + ` durationMs=${result.metadata.executionDurationMs},`
+          + ` prepareMs=${result.metadata.prepareDurationMs},`
+          + ` executeMs=${result.metadata.executeDurationMs},`
+          + ` teardownMs=${result.metadata.teardownDurationMs},`
           + ` maxOutputBytes=${result.metadata.maxOutputBytes},`
           + ` sourceBytes=${result.metadata.sourceBytes}/${result.metadata.maxSourceBytes},`
           + ` runtime=${result.metadata.runtimeCommand ?? '(none)'}`

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -205,6 +205,7 @@ const collectRunCompletionData = async (
         = `sandbox(provider=${result.metadata.providerId}, language=${result.metadata.language},`
           + ` trigger=${result.metadata.triggerType}, timeoutMs=${result.metadata.timeoutMs},`
           + ` maxOutputBytes=${result.metadata.maxOutputBytes},`
+          + ` sourceBytes=${result.metadata.sourceBytes}/${result.metadata.maxSourceBytes},`
           + ` allowEnv=${result.metadata.allowedEnvKeys.join(',') || '(none)'})`
       const failureDetail = stderr.length > 0
         ? `${result.errorMessage}\n${metadataSummary}\n\nstderr:\n${stderr}`

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -211,6 +211,7 @@ const collectRunCompletionData = async (
           + `, outputBytes=${result.metadata.stdoutBytes + result.metadata.stderrBytes}`
           + ` (stdout=${result.metadata.stdoutBytes}, stderr=${result.metadata.stderrBytes}),`
           + ` signal=${result.metadata.terminationSignal ?? '(none)'},`
+          + ` terminationScope=${result.metadata.terminationScope},`
           + ` policy=${result.metadata.policyTriggered},`
           + ` allowEnv=${result.metadata.allowedEnvKeys.join(',') || '(none)'})`
       const failureDetail = stderr.length > 0

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -193,6 +193,30 @@ const collectRunCompletionData = async (
   triggerValue: string | null,
   runId: string
 ) => {
+  if (definition.frontmatter.language !== 'markdown') {
+    const result = await executeScriptWorkflowInSandbox({
+      definition,
+      triggerType,
+      triggerValue
+    })
+    if (result.status === 'failed') {
+      const stderr = result.stderr.trim()
+      const failureDetail = stderr.length > 0
+        ? `${result.errorMessage}\n\nstderr:\n${stderr}`
+        : result.errorMessage
+      throw new Error(failureDetail)
+    }
+
+    completeWorkflowRun({
+      runId,
+      status: 'completed',
+      totalInputTokens: 0,
+      totalCachedInputTokens: 0,
+      totalOutputTokens: 0
+    })
+    return
+  }
+
   const codex = getCodex()
   const prompt = buildRunContextPrompt(definition, triggerType, triggerValue)
   const modelSequence = getWorkflowModelSequence()

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -101,22 +101,6 @@ const shouldApplySelfEvolutionNoOpCommentPolicy = (definition: WorkflowDefinitio
   definition.fileSlug === 'corazon-self-evolution'
   || definition.frontmatter.name.trim().toLowerCase() === 'corazon self evolution'
 
-const buildUnsupportedWorkflowLanguageMessage = (language: string) =>
-  `Workflow language "${language}" is defined but not executable yet. `
-  + 'Only "markdown" workflows can run until the sandboxed script runner lands.'
-
-export const isUnsupportedWorkflowLanguageError = (error: unknown) =>
-  error instanceof Error
-  && error.message.includes('is defined but not executable yet.')
-  && error.message.includes('Only "markdown" workflows can run until the sandboxed script runner lands.')
-
-const ensureRunnableWorkflowLanguage = (definition: WorkflowDefinition) => {
-  if (definition.frontmatter.language === 'markdown') {
-    return
-  }
-  throw new Error(buildUnsupportedWorkflowLanguageMessage(definition.frontmatter.language))
-}
-
 const buildRunContextPrompt = (
   definition: WorkflowDefinition,
   triggerType: WorkflowTriggerType,
@@ -388,7 +372,7 @@ export const executeWorkflowRun = async (
   if (!definition.isValid) {
     throw new Error(definition.parseError ?? 'Invalid workflow definition.')
   }
-  ensureRunnableWorkflowLanguage(definition)
+  assertWorkflowLanguageIsRunnable(definition)
 
   const runningSummary = createRunningWorkflowRun(definition, triggerType, triggerValue)
   return finalizeWorkflowRunExecution({
@@ -406,7 +390,7 @@ export const startWorkflowRun = (
   if (!definition.isValid) {
     throw new Error(definition.parseError ?? 'Invalid workflow definition.')
   }
-  ensureRunnableWorkflowLanguage(definition)
+  assertWorkflowLanguageIsRunnable(definition)
 
   const runningSummary = createRunningWorkflowRun(definition, triggerType, triggerValue)
   void finalizeWorkflowRunExecution({

--- a/server/utils/workflow-runner.ts
+++ b/server/utils/workflow-runner.ts
@@ -206,6 +206,12 @@ const collectRunCompletionData = async (
           + ` trigger=${result.metadata.triggerType}, timeoutMs=${result.metadata.timeoutMs},`
           + ` maxOutputBytes=${result.metadata.maxOutputBytes},`
           + ` sourceBytes=${result.metadata.sourceBytes}/${result.metadata.maxSourceBytes},`
+          + ` runtime=${result.metadata.runtimeCommand ?? '(none)'}`
+          + (result.metadata.runtimeArgs.length > 0 ? ` ${result.metadata.runtimeArgs.join(' ')}` : '')
+          + `, outputBytes=${result.metadata.stdoutBytes + result.metadata.stderrBytes}`
+          + ` (stdout=${result.metadata.stdoutBytes}, stderr=${result.metadata.stderrBytes}),`
+          + ` signal=${result.metadata.terminationSignal ?? '(none)'},`
+          + ` policy=${result.metadata.policyTriggered},`
           + ` allowEnv=${result.metadata.allowedEnvKeys.join(',') || '(none)'})`
       const failureDetail = stderr.length > 0
         ? `${result.errorMessage}\n${metadataSummary}\n\nstderr:\n${stderr}`

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -60,6 +60,8 @@ export type WorkflowScriptExecutionMetadata = {
   triggerType: WorkflowTriggerType
   timeoutMs: number
   maxOutputBytes: number
+  maxSourceBytes: number
+  sourceBytes: number
   allowedEnvKeys: string[]
 }
 
@@ -82,6 +84,8 @@ export const isUnsupportedWorkflowLanguageError = (error: unknown) =>
 const WORKFLOW_SCRIPT_TIMEOUT_MS_DEFAULT = 60_000
 const WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES_DEFAULT = 256_000
 const WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES_MIN = 1_024
+const WORKFLOW_SCRIPT_MAX_SOURCE_BYTES_DEFAULT = 64_000
+const WORKFLOW_SCRIPT_MAX_SOURCE_BYTES_MIN = 256
 
 const resolveScriptTimeoutMs = () => {
   const raw = (process.env.CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS ?? '').trim()
@@ -110,6 +114,18 @@ const resolveScriptMaxOutputBytes = () => {
   const parsed = Number(raw)
   if (!Number.isFinite(parsed) || parsed < WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES_MIN) {
     return WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES_DEFAULT
+  }
+  return Math.floor(parsed)
+}
+
+const resolveScriptMaxSourceBytes = () => {
+  const raw = (process.env.CORAZON_WORKFLOW_SCRIPT_MAX_SOURCE_BYTES ?? '').trim()
+  if (raw === '') {
+    return WORKFLOW_SCRIPT_MAX_SOURCE_BYTES_DEFAULT
+  }
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed < WORKFLOW_SCRIPT_MAX_SOURCE_BYTES_MIN) {
+    return WORKFLOW_SCRIPT_MAX_SOURCE_BYTES_DEFAULT
   }
   return Math.floor(parsed)
 }
@@ -342,6 +358,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
     return
   },
   async execute(context) {
+    const sourceBytes = Buffer.byteLength(context.definition.instruction, 'utf8')
     if (context.definition.frontmatter.language === 'markdown') {
       const metadata: WorkflowScriptExecutionMetadata = {
         providerId: 'local',
@@ -349,6 +366,8 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         triggerType: context.triggerType,
         timeoutMs: resolveScriptTimeoutMs(),
         maxOutputBytes: resolveScriptMaxOutputBytes(),
+        maxSourceBytes: resolveScriptMaxSourceBytes(),
+        sourceBytes,
         allowedEnvKeys: resolveScriptEnvAllowlist()
       }
       return {
@@ -366,6 +385,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
     const language = context.definition.frontmatter.language
     const timeoutMs = resolveScriptTimeoutMs()
     const maxOutputBytes = resolveScriptMaxOutputBytes()
+    const maxSourceBytes = resolveScriptMaxSourceBytes()
     const envAllowlist = resolveScriptEnvAllowlist()
     const metadata: WorkflowScriptExecutionMetadata = {
       providerId: 'local',
@@ -373,7 +393,23 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       triggerType: context.triggerType,
       timeoutMs,
       maxOutputBytes,
+      maxSourceBytes,
+      sourceBytes,
       allowedEnvKeys: [...envAllowlist]
+    }
+    if (sourceBytes > maxSourceBytes) {
+      return {
+        status: 'failed',
+        errorCode: 'policy-violation',
+        errorMessage:
+          `Workflow script source exceeded ${maxSourceBytes} bytes `
+          + `(${sourceBytes} bytes received).`,
+        stdout: '',
+        stderr: '',
+        exitCode: null,
+        durationMs: 0,
+        metadata
+      }
     }
     const tempDirectory = await mkdtemp(join(tmpdir(), 'corazon-workflow-script-'))
     try {
@@ -381,6 +417,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         `[workflow-script-sandbox] provider=${metadata.providerId} phase=prepare`
         + ` language=${metadata.language} trigger=${metadata.triggerType}`
         + ` timeoutMs=${metadata.timeoutMs} maxOutputBytes=${metadata.maxOutputBytes}`
+        + ` sourceBytes=${metadata.sourceBytes}/${metadata.maxSourceBytes}`
         + ` allowEnv=${metadata.allowedEnvKeys.join(',') || '(none)'}`
       )
       await writeRunnableScript(tempDirectory, language, context.definition.instruction)

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -300,11 +300,13 @@ const executeScriptProcess = async (
 
     child.on('close', (exitCode) => {
       clearTimeout(timeoutHandle)
-      if (timedOut) {
+      if (outputLimitExceeded) {
         resolve({
           status: 'failed',
-          errorCode: 'execution-timeout',
-          errorMessage: `Workflow script execution timed out after ${options.timeoutMs}ms.`,
+          errorCode: 'policy-violation',
+          errorMessage:
+            `Workflow script output exceeded ${options.maxOutputBytes} bytes`
+            + (outputLimitStream ? ` on ${outputLimitStream}.` : '.'),
           stdout,
           stderr,
           exitCode: null,
@@ -313,13 +315,11 @@ const executeScriptProcess = async (
         return
       }
 
-      if (outputLimitExceeded) {
+      if (timedOut) {
         resolve({
           status: 'failed',
-          errorCode: 'policy-violation',
-          errorMessage:
-            `Workflow script output exceeded ${options.maxOutputBytes} bytes`
-            + (outputLimitStream ? ` on ${outputLimitStream}.` : '.'),
+          errorCode: 'execution-timeout',
+          errorMessage: `Workflow script execution timed out after ${options.timeoutMs}ms.`,
           stdout,
           stderr,
           exitCode: null,

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -88,6 +88,31 @@ const resolveScriptBinaryByLanguage = (language: Exclude<WorkflowLanguage, 'mark
   return { command: 'node', args: ['script.mjs'] }
 }
 
+const isMissingTypeScriptRuntimeDependency = (error: unknown) => {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  const moduleCode = typeof (error as { code?: unknown }).code === 'string'
+    ? String((error as { code?: unknown }).code)
+    : ''
+  return error.message.includes('Cannot find package \'typescript\'')
+    || (moduleCode === 'ERR_MODULE_NOT_FOUND' && error.message.includes('typescript'))
+}
+
+const formatProviderFailureMessage = (
+  language: Exclude<WorkflowLanguage, 'markdown'>,
+  error: unknown
+) => {
+  if (language === 'typescript' && isMissingTypeScriptRuntimeDependency(error)) {
+    return 'Workflow script provider failed: missing runtime dependency "typescript". '
+      + 'Install the "typescript" package in the runtime environment to execute TypeScript workflows.'
+  }
+  if (error instanceof Error) {
+    return `Workflow script provider failed: ${error.message}`
+  }
+  return 'Workflow script provider failed with an unknown error.'
+}
+
 const transpileTypeScriptToModule = async (source: string) => {
   const typescriptModule = await import('typescript')
   return typescriptModule.transpileModule(source, {
@@ -234,9 +259,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       return {
         status: 'failed',
         errorCode: 'provider-error',
-        errorMessage: error instanceof Error
-          ? `Workflow script provider failed: ${error.message}`
-          : 'Workflow script provider failed with an unknown error.',
+        errorMessage: formatProviderFailureMessage(language, error),
         stdout: '',
         stderr: '',
         exitCode: null,
@@ -252,8 +275,10 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
   }
 }
 
-const resolveConfiguredProviderId = () =>
-  (process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER ?? 'local').trim().toLowerCase()
+const resolveConfiguredProviderId = () => {
+  const configured = (process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER ?? '').trim().toLowerCase()
+  return configured === '' ? 'local' : configured
+}
 
 export const resolveWorkflowScriptSandboxProvider = (): WorkflowScriptSandboxProvider => {
   const configured = resolveConfiguredProviderId()

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -92,11 +92,13 @@ const isMissingTypeScriptRuntimeDependency = (error: unknown) => {
   if (!(error instanceof Error)) {
     return false
   }
+  const message = error.message
   const moduleCode = typeof (error as { code?: unknown }).code === 'string'
     ? String((error as { code?: unknown }).code)
     : ''
-  return error.message.includes('Cannot find package \'typescript\'')
-    || (moduleCode === 'ERR_MODULE_NOT_FOUND' && error.message.includes('typescript'))
+  return message.includes('Cannot find package \'typescript\'')
+    || message.includes('Cannot find module \'typescript\'')
+    || (moduleCode === 'ERR_MODULE_NOT_FOUND' && /['"]typescript['"]/.test(message))
 }
 
 const formatProviderFailureMessage = (

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -69,6 +69,7 @@ export type WorkflowScriptExecutionMetadata = {
   stdoutBytes: number
   stderrBytes: number
   totalOutputBytes: number
+  outputTruncated: boolean
   terminationSignal: NodeJS.Signals | null
   terminationScope: 'none' | 'process' | 'process-group'
   policyTriggered: 'none' | 'source-size' | 'output-size'
@@ -238,6 +239,7 @@ const executeScriptProcess = async (
       durationMs: number
       stdoutBytes: number
       stderrBytes: number
+      outputTruncated: boolean
       terminationSignal: NodeJS.Signals | null
       terminationScope: 'none' | 'process' | 'process-group'
     }
@@ -251,6 +253,7 @@ const executeScriptProcess = async (
       durationMs: number
       stdoutBytes: number
       stderrBytes: number
+      outputTruncated: boolean
       terminationSignal: NodeJS.Signals | null
       terminationScope: 'none' | 'process' | 'process-group'
     }
@@ -260,6 +263,28 @@ const executeScriptProcess = async (
   let stderr = ''
   let stdoutBytes = 0
   let stderrBytes = 0
+  let capturedOutputBytes = 0
+  let outputTruncated = false
+
+  const appendCapturedOutput = (current: string, chunk: string) => {
+    const chunkBytes = Buffer.byteLength(chunk)
+    const remainingCaptureBytes = Math.max(options.maxOutputBytes - capturedOutputBytes, 0)
+    if (remainingCaptureBytes <= 0) {
+      if (chunkBytes > 0) {
+        outputTruncated = true
+      }
+      return current
+    }
+    if (chunkBytes <= remainingCaptureBytes) {
+      capturedOutputBytes += chunkBytes
+      return current + chunk
+    }
+    outputTruncated = true
+    const chunkBuffer = Buffer.from(chunk)
+    const truncatedChunk = chunkBuffer.subarray(0, remainingCaptureBytes).toString('utf8')
+    capturedOutputBytes += remainingCaptureBytes
+    return current + truncatedChunk
+  }
 
   return await new Promise<ProcessExecutionResult>((resolve) => {
     const child = spawn(command, args, {
@@ -304,14 +329,16 @@ const executeScriptProcess = async (
 
     child.stdout.on('data', (chunk) => {
       const text = String(chunk)
-      stdout += text
-      stdoutBytes += Buffer.byteLength(text)
+      const chunkBytes = Buffer.byteLength(text)
+      stdoutBytes += chunkBytes
+      stdout = appendCapturedOutput(stdout, text)
       enforceOutputLimit('stdout')
     })
     child.stderr.on('data', (chunk) => {
       const text = String(chunk)
-      stderr += text
-      stderrBytes += Buffer.byteLength(text)
+      const chunkBytes = Buffer.byteLength(text)
+      stderrBytes += chunkBytes
+      stderr = appendCapturedOutput(stderr, text)
       enforceOutputLimit('stderr')
     })
 
@@ -333,6 +360,7 @@ const executeScriptProcess = async (
         durationMs: Date.now() - startedAt,
         stdoutBytes,
         stderrBytes,
+        outputTruncated,
         terminationSignal: null,
         terminationScope
       })
@@ -353,6 +381,7 @@ const executeScriptProcess = async (
           durationMs: Date.now() - startedAt,
           stdoutBytes,
           stderrBytes,
+          outputTruncated,
           terminationSignal: signal,
           terminationScope
         })
@@ -370,6 +399,7 @@ const executeScriptProcess = async (
           durationMs: Date.now() - startedAt,
           stdoutBytes,
           stderrBytes,
+          outputTruncated,
           terminationSignal: signal,
           terminationScope
         })
@@ -387,6 +417,7 @@ const executeScriptProcess = async (
           durationMs: Date.now() - startedAt,
           stdoutBytes,
           stderrBytes,
+          outputTruncated,
           terminationSignal: signal,
           terminationScope
         })
@@ -401,6 +432,7 @@ const executeScriptProcess = async (
         durationMs: Date.now() - startedAt,
         stdoutBytes,
         stderrBytes,
+        outputTruncated,
         terminationSignal: signal,
         terminationScope
       })
@@ -432,6 +464,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         stdoutBytes: 0,
         stderrBytes: 0,
         totalOutputBytes: 0,
+        outputTruncated: false,
         terminationSignal: null,
         terminationScope: 'none',
         policyTriggered: 'none',
@@ -469,6 +502,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       stdoutBytes: 0,
       stderrBytes: 0,
       totalOutputBytes: 0,
+      outputTruncated: false,
       terminationSignal: null,
       terminationScope: 'none',
       policyTriggered: 'none',
@@ -519,6 +553,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       metadata.stdoutBytes = executionResult.stdoutBytes
       metadata.stderrBytes = executionResult.stderrBytes
       metadata.totalOutputBytes = executionResult.stdoutBytes + executionResult.stderrBytes
+      metadata.outputTruncated = executionResult.outputTruncated
       metadata.terminationSignal = executionResult.terminationSignal
       metadata.terminationScope = executionResult.terminationScope
       metadata.executionDurationMs = executionResult.durationMs

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -58,6 +58,7 @@ export type WorkflowScriptExecutionMetadata = {
   providerId: WorkflowScriptSandboxProviderId
   language: WorkflowLanguage
   triggerType: WorkflowTriggerType
+  executionDurationMs: number
   timeoutMs: number
   maxOutputBytes: number
   maxSourceBytes: number
@@ -413,12 +414,14 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
     return
   },
   async execute(context) {
+    const startedAt = Date.now()
     const sourceBytes = Buffer.byteLength(context.definition.instruction, 'utf8')
     if (context.definition.frontmatter.language === 'markdown') {
       const metadata: WorkflowScriptExecutionMetadata = {
         providerId: 'local',
         language: 'markdown',
         triggerType: context.triggerType,
+        executionDurationMs: 0,
         timeoutMs: resolveScriptTimeoutMs(),
         maxOutputBytes: resolveScriptMaxOutputBytes(),
         maxSourceBytes: resolveScriptMaxSourceBytes(),
@@ -455,6 +458,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       providerId: 'local',
       language,
       triggerType: context.triggerType,
+      executionDurationMs: 0,
       timeoutMs,
       maxOutputBytes,
       maxSourceBytes,
@@ -472,6 +476,8 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
     }
     if (sourceBytes > maxSourceBytes) {
       metadata.policyTriggered = 'source-size'
+      const durationMs = Date.now() - startedAt
+      metadata.executionDurationMs = durationMs
       return {
         status: 'failed',
         errorCode: 'policy-violation',
@@ -481,7 +487,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         stdout: '',
         stderr: '',
         exitCode: null,
-        durationMs: 0,
+        durationMs,
         metadata
       }
     }
@@ -515,6 +521,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       metadata.totalOutputBytes = executionResult.stdoutBytes + executionResult.stderrBytes
       metadata.terminationSignal = executionResult.terminationSignal
       metadata.terminationScope = executionResult.terminationScope
+      metadata.executionDurationMs = executionResult.durationMs
       if (executionResult.status === 'failed' && executionResult.errorCode === 'policy-violation') {
         metadata.policyTriggered = 'output-size'
       }
@@ -541,6 +548,8 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
     } catch (error) {
       metadata.failurePhase = executionPhase
       const message = formatProviderFailureMessage(language, error)
+      const durationMs = Date.now() - startedAt
+      metadata.executionDurationMs = durationMs
       console.warn(
         `[workflow-script-sandbox] provider=${metadata.providerId} phase=teardown`
         + ' status=failed errorCode=provider-error'
@@ -553,7 +562,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         stdout: '',
         stderr: '',
         exitCode: null,
-        durationMs: 0,
+        durationMs,
         metadata
       }
     } finally {

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -155,10 +155,11 @@ const resolveScriptEnvAllowlist = () => {
     .filter(Boolean))]
 }
 
-const buildScriptExecutionEnv = (allowlist: string[]) => {
+const buildScriptExecutionEnv = (allowlist: string[], sandboxDirectory: string) => {
   const env: Record<string, string> = {
     PATH: process.env.PATH ?? '',
-    HOME: process.env.HOME ?? ''
+    HOME: sandboxDirectory,
+    TMPDIR: sandboxDirectory
   }
 
   for (const key of allowlist) {
@@ -293,7 +294,7 @@ const executeScriptProcess = async (
     const child = spawn(command, args, {
       cwd: options.cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: buildScriptExecutionEnv(options.envAllowlist),
+      env: buildScriptExecutionEnv(options.envAllowlist, options.cwd),
       detached: process.platform !== 'win32'
     })
     let terminationScope: 'none' | 'process' | 'process-group' = 'none'

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -1,0 +1,90 @@
+import type {
+  WorkflowDefinition,
+  WorkflowLanguage,
+  WorkflowTriggerType
+} from '@@/types/workflow'
+
+export type WorkflowScriptSandboxProviderId = 'local'
+export type WorkflowScriptSandboxErrorCode = 'unsupported-language' | 'unsupported-provider'
+
+export class WorkflowScriptSandboxError extends Error {
+  readonly code: WorkflowScriptSandboxErrorCode
+  readonly providerId: string
+
+  constructor(code: WorkflowScriptSandboxErrorCode, providerId: string, message: string) {
+    super(message)
+    this.code = code
+    this.providerId = providerId
+  }
+}
+
+export type WorkflowScriptExecutionContext = {
+  definition: WorkflowDefinition
+  triggerType: WorkflowTriggerType
+  triggerValue: string | null
+}
+
+export type WorkflowScriptExecutionResult = { status: 'completed' } | { status: 'failed', errorMessage: string }
+
+export type WorkflowScriptSandboxProvider = {
+  id: WorkflowScriptSandboxProviderId
+  assertLanguageSupported: (language: Exclude<WorkflowLanguage, 'markdown'>) => void
+  execute: (context: WorkflowScriptExecutionContext) => Promise<WorkflowScriptExecutionResult>
+}
+
+export const buildUnsupportedWorkflowLanguageMessage = (language: string) =>
+  `Workflow language "${language}" is defined but not executable yet. `
+  + 'Only "markdown" workflows can run until the sandboxed script runner lands.'
+
+export const isUnsupportedWorkflowLanguageError = (error: unknown) =>
+  (error instanceof WorkflowScriptSandboxError && error.code === 'unsupported-language')
+  || (error instanceof Error
+    && error.message.includes('is defined but not executable yet.')
+    && error.message.includes('Only "markdown" workflows can run until the sandboxed script runner lands.'))
+
+const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
+  id: 'local',
+  assertLanguageSupported(language) {
+    throw new WorkflowScriptSandboxError(
+      'unsupported-language',
+      'local',
+      buildUnsupportedWorkflowLanguageMessage(language)
+    )
+  },
+  async execute(context) {
+    return {
+      status: 'failed',
+      errorMessage: buildUnsupportedWorkflowLanguageMessage(context.definition.frontmatter.language)
+    }
+  }
+}
+
+const resolveConfiguredProviderId = () =>
+  (process.env.CORAZON_WORKFLOW_SCRIPT_SANDBOX_PROVIDER ?? 'local').trim().toLowerCase()
+
+export const resolveWorkflowScriptSandboxProvider = (): WorkflowScriptSandboxProvider => {
+  const configured = resolveConfiguredProviderId()
+  if (configured === 'local') {
+    return localScriptSandboxProvider
+  }
+
+  throw new WorkflowScriptSandboxError(
+    'unsupported-provider',
+    configured,
+    `Unsupported workflow script sandbox provider: "${configured}".`
+  )
+}
+
+export const assertWorkflowLanguageIsRunnable = (definition: WorkflowDefinition) => {
+  if (definition.frontmatter.language === 'markdown') {
+    return
+  }
+
+  const provider = resolveWorkflowScriptSandboxProvider()
+  provider.assertLanguageSupported(definition.frontmatter.language)
+}
+
+export const executeScriptWorkflowInSandbox = async (context: WorkflowScriptExecutionContext) => {
+  const provider = resolveWorkflowScriptSandboxProvider()
+  return provider.execute(context)
+}

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -156,6 +156,7 @@ const resolveScriptEnvAllowlist = () => {
 }
 
 const buildScriptExecutionEnv = (allowlist: string[], sandboxDirectory: string) => {
+  const reservedKeys = new Set(['HOME', 'TMPDIR'])
   const env: Record<string, string> = {
     PATH: process.env.PATH ?? '',
     HOME: sandboxDirectory,
@@ -163,6 +164,9 @@ const buildScriptExecutionEnv = (allowlist: string[], sandboxDirectory: string) 
   }
 
   for (const key of allowlist) {
+    if (reservedKeys.has(key)) {
+      continue
+    }
     const value = process.env[key]
     if (typeof value === 'string') {
       env[key] = value

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawn } from 'node:child_process'
 import type {
   WorkflowDefinition,
   WorkflowLanguage,
@@ -5,7 +9,12 @@ import type {
 } from '@@/types/workflow'
 
 export type WorkflowScriptSandboxProviderId = 'local'
-export type WorkflowScriptSandboxErrorCode = 'unsupported-language' | 'unsupported-provider'
+export type WorkflowScriptSandboxErrorCode
+  = | 'unsupported-language'
+    | 'unsupported-provider'
+    | 'execution-timeout'
+    | 'execution-failed'
+    | 'provider-error'
 
 export class WorkflowScriptSandboxError extends Error {
   readonly code: WorkflowScriptSandboxErrorCode
@@ -24,7 +33,23 @@ export type WorkflowScriptExecutionContext = {
   triggerValue: string | null
 }
 
-export type WorkflowScriptExecutionResult = { status: 'completed' } | { status: 'failed', errorMessage: string }
+export type WorkflowScriptExecutionResult
+  = | {
+    status: 'completed'
+    stdout: string
+    stderr: string
+    exitCode: number
+    durationMs: number
+  }
+  | {
+    status: 'failed'
+    errorCode: WorkflowScriptSandboxErrorCode
+    errorMessage: string
+    stdout: string
+    stderr: string
+    exitCode: number | null
+    durationMs: number
+  }
 
 export type WorkflowScriptSandboxProvider = {
   id: WorkflowScriptSandboxProviderId
@@ -42,19 +67,187 @@ export const isUnsupportedWorkflowLanguageError = (error: unknown) =>
     && error.message.includes('is defined but not executable yet.')
     && error.message.includes('Only "markdown" workflows can run until the sandboxed script runner lands.'))
 
+const WORKFLOW_SCRIPT_TIMEOUT_MS_DEFAULT = 60_000
+
+const resolveScriptTimeoutMs = () => {
+  const raw = (process.env.CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS ?? '').trim()
+  if (raw === '') {
+    return WORKFLOW_SCRIPT_TIMEOUT_MS_DEFAULT
+  }
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return WORKFLOW_SCRIPT_TIMEOUT_MS_DEFAULT
+  }
+  return Math.floor(parsed)
+}
+
+const resolveScriptBinaryByLanguage = (language: Exclude<WorkflowLanguage, 'markdown'>) => {
+  if (language === 'python') {
+    return { command: process.env.CORAZON_WORKFLOW_PYTHON_BIN?.trim() || 'python3', args: ['script.py'] }
+  }
+  return { command: 'node', args: ['script.mjs'] }
+}
+
+const transpileTypeScriptToModule = async (source: string) => {
+  const typescriptModule = await import('typescript')
+  return typescriptModule.transpileModule(source, {
+    compilerOptions: {
+      target: typescriptModule.ScriptTarget.ES2022,
+      module: typescriptModule.ModuleKind.ES2022,
+      moduleResolution: typescriptModule.ModuleResolutionKind.Bundler
+    }
+  }).outputText
+}
+
+const writeRunnableScript = async (
+  directory: string,
+  language: Exclude<WorkflowLanguage, 'markdown'>,
+  source: string
+) => {
+  if (language === 'python') {
+    const scriptPath = join(directory, 'script.py')
+    await writeFile(scriptPath, `${source.trim()}\n`, 'utf8')
+    return
+  }
+  const transpiled = await transpileTypeScriptToModule(source)
+  const scriptPath = join(directory, 'script.mjs')
+  await writeFile(scriptPath, transpiled, 'utf8')
+}
+
+const executeScriptProcess = async (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string
+    timeoutMs: number
+  }
+) => {
+  const startedAt = Date.now()
+  let stdout = ''
+  let stderr = ''
+
+  return await new Promise<WorkflowScriptExecutionResult>((resolve) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        PATH: process.env.PATH ?? '',
+        HOME: process.env.HOME ?? ''
+      }
+    })
+
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk)
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk)
+    })
+
+    let timedOut = false
+    const timeoutHandle = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, options.timeoutMs)
+
+    child.on('error', (error) => {
+      clearTimeout(timeoutHandle)
+      resolve({
+        status: 'failed',
+        errorCode: 'provider-error',
+        errorMessage: `Failed to start script runtime: ${error.message}`,
+        stdout,
+        stderr,
+        exitCode: null,
+        durationMs: Date.now() - startedAt
+      })
+    })
+
+    child.on('close', (exitCode) => {
+      clearTimeout(timeoutHandle)
+      if (timedOut) {
+        resolve({
+          status: 'failed',
+          errorCode: 'execution-timeout',
+          errorMessage: `Workflow script execution timed out after ${options.timeoutMs}ms.`,
+          stdout,
+          stderr,
+          exitCode: null,
+          durationMs: Date.now() - startedAt
+        })
+        return
+      }
+
+      if (exitCode !== 0) {
+        resolve({
+          status: 'failed',
+          errorCode: 'execution-failed',
+          errorMessage: `Workflow script process exited with code ${exitCode}.`,
+          stdout,
+          stderr,
+          exitCode: exitCode ?? null,
+          durationMs: Date.now() - startedAt
+        })
+        return
+      }
+
+      resolve({
+        status: 'completed',
+        stdout,
+        stderr,
+        exitCode: 0,
+        durationMs: Date.now() - startedAt
+      })
+    })
+  })
+}
+
 const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
   id: 'local',
-  assertLanguageSupported(language) {
-    throw new WorkflowScriptSandboxError(
-      'unsupported-language',
-      'local',
-      buildUnsupportedWorkflowLanguageMessage(language)
-    )
+  assertLanguageSupported(_language) {
+    return
   },
   async execute(context) {
-    return {
-      status: 'failed',
-      errorMessage: buildUnsupportedWorkflowLanguageMessage(context.definition.frontmatter.language)
+    if (context.definition.frontmatter.language === 'markdown') {
+      return {
+        status: 'failed',
+        errorCode: 'unsupported-language',
+        errorMessage: 'Markdown workflows must use the standard LLM execution path.',
+        stdout: '',
+        stderr: '',
+        exitCode: null,
+        durationMs: 0
+      }
+    }
+
+    const language = context.definition.frontmatter.language
+    const timeoutMs = resolveScriptTimeoutMs()
+    const tempDirectory = await mkdtemp(join(tmpdir(), 'corazon-workflow-script-'))
+    try {
+      await writeRunnableScript(tempDirectory, language, context.definition.instruction)
+      const runtime = resolveScriptBinaryByLanguage(language)
+      const executionResult = await executeScriptProcess(runtime.command, runtime.args, {
+        cwd: tempDirectory,
+        timeoutMs
+      })
+      return executionResult
+    } catch (error) {
+      return {
+        status: 'failed',
+        errorCode: 'provider-error',
+        errorMessage: error instanceof Error
+          ? `Workflow script provider failed: ${error.message}`
+          : 'Workflow script provider failed with an unknown error.',
+        stdout: '',
+        stderr: '',
+        exitCode: null,
+        durationMs: 0
+      }
+    } finally {
+      try {
+        await rm(tempDirectory, { recursive: true, force: true })
+      } catch {
+        // no-op cleanup guard
+      }
     }
   }
 }

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -14,6 +14,7 @@ export type WorkflowScriptSandboxErrorCode
     | 'unsupported-provider'
     | 'execution-timeout'
     | 'execution-failed'
+    | 'policy-violation'
     | 'provider-error'
 
 export class WorkflowScriptSandboxError extends Error {
@@ -40,6 +41,7 @@ export type WorkflowScriptExecutionResult
     stderr: string
     exitCode: number
     durationMs: number
+    metadata: WorkflowScriptExecutionMetadata
   }
   | {
     status: 'failed'
@@ -49,7 +51,17 @@ export type WorkflowScriptExecutionResult
     stderr: string
     exitCode: number | null
     durationMs: number
+    metadata: WorkflowScriptExecutionMetadata
   }
+
+export type WorkflowScriptExecutionMetadata = {
+  providerId: WorkflowScriptSandboxProviderId
+  language: WorkflowLanguage
+  triggerType: WorkflowTriggerType
+  timeoutMs: number
+  maxOutputBytes: number
+  allowedEnvKeys: string[]
+}
 
 export type WorkflowScriptSandboxProvider = {
   id: WorkflowScriptSandboxProviderId
@@ -68,6 +80,8 @@ export const isUnsupportedWorkflowLanguageError = (error: unknown) =>
     && error.message.includes('Only "markdown" workflows can run until the sandboxed script runner lands.'))
 
 const WORKFLOW_SCRIPT_TIMEOUT_MS_DEFAULT = 60_000
+const WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES_DEFAULT = 256_000
+const WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES_MIN = 1_024
 
 const resolveScriptTimeoutMs = () => {
   const raw = (process.env.CORAZON_WORKFLOW_SCRIPT_TIMEOUT_MS ?? '').trim()
@@ -86,6 +100,44 @@ const resolveScriptBinaryByLanguage = (language: Exclude<WorkflowLanguage, 'mark
     return { command: process.env.CORAZON_WORKFLOW_PYTHON_BIN?.trim() || 'python3', args: ['script.py'] }
   }
   return { command: 'node', args: ['script.mjs'] }
+}
+
+const resolveScriptMaxOutputBytes = () => {
+  const raw = (process.env.CORAZON_WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES ?? '').trim()
+  if (raw === '') {
+    return WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES_DEFAULT
+  }
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed < WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES_MIN) {
+    return WORKFLOW_SCRIPT_MAX_OUTPUT_BYTES_DEFAULT
+  }
+  return Math.floor(parsed)
+}
+
+const resolveScriptEnvAllowlist = () => {
+  const raw = (process.env.CORAZON_WORKFLOW_SCRIPT_ENV_ALLOWLIST ?? '').trim()
+  if (raw === '') {
+    return [] as string[]
+  }
+  return [...new Set(raw
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean))]
+}
+
+const buildScriptExecutionEnv = (allowlist: string[]) => {
+  const env: Record<string, string> = {
+    PATH: process.env.PATH ?? '',
+    HOME: process.env.HOME ?? ''
+  }
+
+  for (const key of allowlist) {
+    const value = process.env[key]
+    if (typeof value === 'string') {
+      env[key] = value
+    }
+  }
+  return env
 }
 
 const isMissingTypeScriptRuntimeDependency = (error: unknown) => {
@@ -147,27 +199,68 @@ const executeScriptProcess = async (
   options: {
     cwd: string
     timeoutMs: number
+    maxOutputBytes: number
+    envAllowlist: string[]
   }
 ) => {
+  type ProcessExecutionResult
+    = | {
+      status: 'completed'
+      stdout: string
+      stderr: string
+      exitCode: number
+      durationMs: number
+    }
+    | {
+      status: 'failed'
+      errorCode: WorkflowScriptSandboxErrorCode
+      errorMessage: string
+      stdout: string
+      stderr: string
+      exitCode: number | null
+      durationMs: number
+    }
+
   const startedAt = Date.now()
   let stdout = ''
   let stderr = ''
+  let stdoutBytes = 0
+  let stderrBytes = 0
 
-  return await new Promise<WorkflowScriptExecutionResult>((resolve) => {
+  return await new Promise<ProcessExecutionResult>((resolve) => {
     const child = spawn(command, args, {
       cwd: options.cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
-        PATH: process.env.PATH ?? '',
-        HOME: process.env.HOME ?? ''
-      }
+      env: buildScriptExecutionEnv(options.envAllowlist)
     })
 
+    const totalOutputBytes = () => stdoutBytes + stderrBytes
+    let outputLimitExceeded = false
+    let outputLimitStream: 'stdout' | 'stderr' | null = null
+
+    const enforceOutputLimit = (stream: 'stdout' | 'stderr') => {
+      if (outputLimitExceeded) {
+        return
+      }
+      if (totalOutputBytes() <= options.maxOutputBytes) {
+        return
+      }
+      outputLimitExceeded = true
+      outputLimitStream = stream
+      child.kill('SIGKILL')
+    }
+
     child.stdout.on('data', (chunk) => {
-      stdout += String(chunk)
+      const text = String(chunk)
+      stdout += text
+      stdoutBytes += Buffer.byteLength(text)
+      enforceOutputLimit('stdout')
     })
     child.stderr.on('data', (chunk) => {
-      stderr += String(chunk)
+      const text = String(chunk)
+      stderr += text
+      stderrBytes += Buffer.byteLength(text)
+      enforceOutputLimit('stderr')
     })
 
     let timedOut = false
@@ -196,6 +289,21 @@ const executeScriptProcess = async (
           status: 'failed',
           errorCode: 'execution-timeout',
           errorMessage: `Workflow script execution timed out after ${options.timeoutMs}ms.`,
+          stdout,
+          stderr,
+          exitCode: null,
+          durationMs: Date.now() - startedAt
+        })
+        return
+      }
+
+      if (outputLimitExceeded) {
+        resolve({
+          status: 'failed',
+          errorCode: 'policy-violation',
+          errorMessage:
+            `Workflow script output exceeded ${options.maxOutputBytes} bytes`
+            + (outputLimitStream ? ` on ${outputLimitStream}.` : '.'),
           stdout,
           stderr,
           exitCode: null,
@@ -235,6 +343,14 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
   },
   async execute(context) {
     if (context.definition.frontmatter.language === 'markdown') {
+      const metadata: WorkflowScriptExecutionMetadata = {
+        providerId: 'local',
+        language: 'markdown',
+        triggerType: context.triggerType,
+        timeoutMs: resolveScriptTimeoutMs(),
+        maxOutputBytes: resolveScriptMaxOutputBytes(),
+        allowedEnvKeys: resolveScriptEnvAllowlist()
+      }
       return {
         status: 'failed',
         errorCode: 'unsupported-language',
@@ -242,21 +358,47 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         stdout: '',
         stderr: '',
         exitCode: null,
-        durationMs: 0
+        durationMs: 0,
+        metadata
       }
     }
 
     const language = context.definition.frontmatter.language
     const timeoutMs = resolveScriptTimeoutMs()
+    const maxOutputBytes = resolveScriptMaxOutputBytes()
+    const envAllowlist = resolveScriptEnvAllowlist()
+    const metadata: WorkflowScriptExecutionMetadata = {
+      providerId: 'local',
+      language,
+      triggerType: context.triggerType,
+      timeoutMs,
+      maxOutputBytes,
+      allowedEnvKeys: [...envAllowlist]
+    }
     const tempDirectory = await mkdtemp(join(tmpdir(), 'corazon-workflow-script-'))
     try {
+      console.info(
+        `[workflow-script-sandbox] provider=${metadata.providerId} phase=prepare`
+        + ` language=${metadata.language} trigger=${metadata.triggerType}`
+        + ` timeoutMs=${metadata.timeoutMs} maxOutputBytes=${metadata.maxOutputBytes}`
+        + ` allowEnv=${metadata.allowedEnvKeys.join(',') || '(none)'}`
+      )
       await writeRunnableScript(tempDirectory, language, context.definition.instruction)
       const runtime = resolveScriptBinaryByLanguage(language)
       const executionResult = await executeScriptProcess(runtime.command, runtime.args, {
         cwd: tempDirectory,
-        timeoutMs
+        timeoutMs,
+        maxOutputBytes,
+        envAllowlist
       })
-      return executionResult
+      console.info(
+        `[workflow-script-sandbox] provider=${metadata.providerId} phase=teardown`
+        + ` status=${executionResult.status} durationMs=${executionResult.durationMs}`
+      )
+      return {
+        ...executionResult,
+        metadata
+      }
     } catch (error) {
       return {
         status: 'failed',
@@ -265,7 +407,8 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         stdout: '',
         stderr: '',
         exitCode: null,
-        durationMs: 0
+        durationMs: 0,
+        metadata
       }
     } finally {
       try {

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -69,6 +69,7 @@ export type WorkflowScriptExecutionMetadata = {
   stderrBytes: number
   totalOutputBytes: number
   terminationSignal: NodeJS.Signals | null
+  terminationScope: 'none' | 'process' | 'process-group'
   policyTriggered: 'none' | 'source-size' | 'output-size'
 }
 
@@ -236,6 +237,7 @@ const executeScriptProcess = async (
       stdoutBytes: number
       stderrBytes: number
       terminationSignal: NodeJS.Signals | null
+      terminationScope: 'none' | 'process' | 'process-group'
     }
     | {
       status: 'failed'
@@ -248,6 +250,7 @@ const executeScriptProcess = async (
       stdoutBytes: number
       stderrBytes: number
       terminationSignal: NodeJS.Signals | null
+      terminationScope: 'none' | 'process' | 'process-group'
     }
 
   const startedAt = Date.now()
@@ -260,8 +263,26 @@ const executeScriptProcess = async (
     const child = spawn(command, args, {
       cwd: options.cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: buildScriptExecutionEnv(options.envAllowlist)
+      env: buildScriptExecutionEnv(options.envAllowlist),
+      detached: process.platform !== 'win32'
     })
+    let terminationScope: 'none' | 'process' | 'process-group' = 'none'
+
+    const killExecution = (signal: NodeJS.Signals = 'SIGKILL') => {
+      if (process.platform !== 'win32' && typeof child.pid === 'number' && child.pid > 0) {
+        try {
+          process.kill(-child.pid, signal)
+          terminationScope = 'process-group'
+          return
+        } catch {
+          // fall through to single-process kill
+        }
+      }
+
+      if (child.kill(signal)) {
+        terminationScope = 'process'
+      }
+    }
 
     const totalOutputBytes = () => stdoutBytes + stderrBytes
     let outputLimitExceeded = false
@@ -276,7 +297,7 @@ const executeScriptProcess = async (
       }
       outputLimitExceeded = true
       outputLimitStream = stream
-      child.kill('SIGKILL')
+      killExecution('SIGKILL')
     }
 
     child.stdout.on('data', (chunk) => {
@@ -295,7 +316,7 @@ const executeScriptProcess = async (
     let timedOut = false
     const timeoutHandle = setTimeout(() => {
       timedOut = true
-      child.kill('SIGKILL')
+      killExecution('SIGKILL')
     }, options.timeoutMs)
 
     child.on('error', (error) => {
@@ -310,7 +331,8 @@ const executeScriptProcess = async (
         durationMs: Date.now() - startedAt,
         stdoutBytes,
         stderrBytes,
-        terminationSignal: null
+        terminationSignal: null,
+        terminationScope
       })
     })
 
@@ -329,7 +351,8 @@ const executeScriptProcess = async (
           durationMs: Date.now() - startedAt,
           stdoutBytes,
           stderrBytes,
-          terminationSignal: signal
+          terminationSignal: signal,
+          terminationScope
         })
         return
       }
@@ -345,7 +368,8 @@ const executeScriptProcess = async (
           durationMs: Date.now() - startedAt,
           stdoutBytes,
           stderrBytes,
-          terminationSignal: signal
+          terminationSignal: signal,
+          terminationScope
         })
         return
       }
@@ -361,7 +385,8 @@ const executeScriptProcess = async (
           durationMs: Date.now() - startedAt,
           stdoutBytes,
           stderrBytes,
-          terminationSignal: signal
+          terminationSignal: signal,
+          terminationScope
         })
         return
       }
@@ -374,7 +399,8 @@ const executeScriptProcess = async (
         durationMs: Date.now() - startedAt,
         stdoutBytes,
         stderrBytes,
-        terminationSignal: signal
+        terminationSignal: signal,
+        terminationScope
       })
     })
   })
@@ -403,6 +429,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         stderrBytes: 0,
         totalOutputBytes: 0,
         terminationSignal: null,
+        terminationScope: 'none',
         policyTriggered: 'none'
       }
       return {
@@ -437,6 +464,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       stderrBytes: 0,
       totalOutputBytes: 0,
       terminationSignal: null,
+      terminationScope: 'none',
       policyTriggered: 'none'
     }
     if (sourceBytes > maxSourceBytes) {
@@ -481,6 +509,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       metadata.stderrBytes = executionResult.stderrBytes
       metadata.totalOutputBytes = executionResult.stdoutBytes + executionResult.stderrBytes
       metadata.terminationSignal = executionResult.terminationSignal
+      metadata.terminationScope = executionResult.terminationScope
       if (executionResult.status === 'failed' && executionResult.errorCode === 'policy-violation') {
         metadata.policyTriggered = 'output-size'
       }
@@ -489,6 +518,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         + ` status=${executionResult.status} durationMs=${executionResult.durationMs}`
         + ` stdoutBytes=${executionResult.stdoutBytes} stderrBytes=${executionResult.stderrBytes}`
         + ` signal=${executionResult.terminationSignal ?? '(none)'}`
+        + ` terminationScope=${executionResult.terminationScope}`
         + (executionResult.status === 'failed'
           ? ` errorCode=${executionResult.errorCode}`
           : '')

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -59,6 +59,9 @@ export type WorkflowScriptExecutionMetadata = {
   language: WorkflowLanguage
   triggerType: WorkflowTriggerType
   executionDurationMs: number
+  prepareDurationMs: number
+  executeDurationMs: number
+  teardownDurationMs: number
   timeoutMs: number
   maxOutputBytes: number
   maxSourceBytes: number
@@ -454,6 +457,9 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         language: 'markdown',
         triggerType: context.triggerType,
         executionDurationMs: 0,
+        prepareDurationMs: 0,
+        executeDurationMs: 0,
+        teardownDurationMs: 0,
         timeoutMs: resolveScriptTimeoutMs(),
         maxOutputBytes: resolveScriptMaxOutputBytes(),
         maxSourceBytes: resolveScriptMaxSourceBytes(),
@@ -492,6 +498,9 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       language,
       triggerType: context.triggerType,
       executionDurationMs: 0,
+      prepareDurationMs: 0,
+      executeDurationMs: 0,
+      teardownDurationMs: 0,
       timeoutMs,
       maxOutputBytes,
       maxSourceBytes,
@@ -527,6 +536,8 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
     }
     const tempDirectory = await mkdtemp(join(tmpdir(), 'corazon-workflow-script-'))
     let executionPhase: 'prepare' | 'execute' = 'prepare'
+    let executeStartedAt: number | null = null
+    let result: WorkflowScriptExecutionResult | null = null
     try {
       console.info(
         `[workflow-script-sandbox] provider=${metadata.providerId} phase=prepare`
@@ -537,9 +548,11 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       )
       await writeRunnableScript(tempDirectory, language, context.definition.instruction)
       const runtime = resolveScriptBinaryByLanguage(language)
+      metadata.prepareDurationMs = Date.now() - startedAt
       metadata.runtimeCommand = runtime.command
       metadata.runtimeArgs = [...runtime.args]
       executionPhase = 'execute'
+      executeStartedAt = Date.now()
       console.info(
         `[workflow-script-sandbox] provider=${metadata.providerId} phase=execute-start`
         + ` command=${runtime.command} args=${runtime.args.join(' ') || '(none)'}`
@@ -557,6 +570,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       metadata.terminationSignal = executionResult.terminationSignal
       metadata.terminationScope = executionResult.terminationScope
       metadata.executionDurationMs = executionResult.durationMs
+      metadata.executeDurationMs = executionResult.durationMs
       if (executionResult.status === 'failed' && executionResult.errorCode === 'policy-violation') {
         metadata.policyTriggered = 'output-size'
       }
@@ -575,22 +589,35 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         + (executionResult.status === 'failed' && executionResult.errorCode === 'provider-error'
           ? ` failurePhase=${metadata.failurePhase}`
           : '')
+        + ` prepareDurationMs=${metadata.prepareDurationMs}`
+        + ` executeDurationMs=${metadata.executeDurationMs}`
+        + ` teardownDurationMs=${metadata.teardownDurationMs}`
       )
-      return {
+      result = {
         ...executionResult,
         metadata
       }
+      return result
     } catch (error) {
       metadata.failurePhase = executionPhase
       const message = formatProviderFailureMessage(language, error)
       const durationMs = Date.now() - startedAt
       metadata.executionDurationMs = durationMs
+      if (executionPhase === 'prepare') {
+        metadata.prepareDurationMs = durationMs
+      }
+      if (executionPhase === 'execute' && executeStartedAt !== null) {
+        metadata.executeDurationMs = Date.now() - executeStartedAt
+      }
       console.warn(
         `[workflow-script-sandbox] provider=${metadata.providerId} phase=teardown`
         + ' status=failed errorCode=provider-error'
         + ` failurePhase=${metadata.failurePhase} message=${message}`
+        + ` prepareDurationMs=${metadata.prepareDurationMs}`
+        + ` executeDurationMs=${metadata.executeDurationMs}`
+        + ` teardownDurationMs=${metadata.teardownDurationMs}`
       )
-      return {
+      result = {
         status: 'failed',
         errorCode: 'provider-error',
         errorMessage: message,
@@ -600,11 +627,18 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         durationMs,
         metadata
       }
+      return result
     } finally {
+      const teardownStartedAt = Date.now()
       try {
         await rm(tempDirectory, { recursive: true, force: true })
       } catch {
         // no-op cleanup guard
+      } finally {
+        metadata.teardownDurationMs = Date.now() - teardownStartedAt
+        if (result !== null) {
+          result.metadata.teardownDurationMs = metadata.teardownDurationMs
+        }
       }
     }
   }

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -530,6 +530,9 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         + (executionResult.status === 'failed'
           ? ` errorCode=${executionResult.errorCode}`
           : '')
+        + (executionResult.status === 'failed' && executionResult.errorCode === 'provider-error'
+          ? ` failurePhase=${metadata.failurePhase}`
+          : '')
       )
       return {
         ...executionResult,

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -63,6 +63,13 @@ export type WorkflowScriptExecutionMetadata = {
   maxSourceBytes: number
   sourceBytes: number
   allowedEnvKeys: string[]
+  runtimeCommand: string | null
+  runtimeArgs: string[]
+  stdoutBytes: number
+  stderrBytes: number
+  totalOutputBytes: number
+  terminationSignal: NodeJS.Signals | null
+  policyTriggered: 'none' | 'source-size' | 'output-size'
 }
 
 export type WorkflowScriptSandboxProvider = {
@@ -226,6 +233,9 @@ const executeScriptProcess = async (
       stderr: string
       exitCode: number
       durationMs: number
+      stdoutBytes: number
+      stderrBytes: number
+      terminationSignal: NodeJS.Signals | null
     }
     | {
       status: 'failed'
@@ -235,6 +245,9 @@ const executeScriptProcess = async (
       stderr: string
       exitCode: number | null
       durationMs: number
+      stdoutBytes: number
+      stderrBytes: number
+      terminationSignal: NodeJS.Signals | null
     }
 
   const startedAt = Date.now()
@@ -294,11 +307,14 @@ const executeScriptProcess = async (
         stdout,
         stderr,
         exitCode: null,
-        durationMs: Date.now() - startedAt
+        durationMs: Date.now() - startedAt,
+        stdoutBytes,
+        stderrBytes,
+        terminationSignal: null
       })
     })
 
-    child.on('close', (exitCode) => {
+    child.on('close', (exitCode, signal) => {
       clearTimeout(timeoutHandle)
       if (outputLimitExceeded) {
         resolve({
@@ -310,7 +326,10 @@ const executeScriptProcess = async (
           stdout,
           stderr,
           exitCode: null,
-          durationMs: Date.now() - startedAt
+          durationMs: Date.now() - startedAt,
+          stdoutBytes,
+          stderrBytes,
+          terminationSignal: signal
         })
         return
       }
@@ -323,7 +342,10 @@ const executeScriptProcess = async (
           stdout,
           stderr,
           exitCode: null,
-          durationMs: Date.now() - startedAt
+          durationMs: Date.now() - startedAt,
+          stdoutBytes,
+          stderrBytes,
+          terminationSignal: signal
         })
         return
       }
@@ -336,7 +358,10 @@ const executeScriptProcess = async (
           stdout,
           stderr,
           exitCode: exitCode ?? null,
-          durationMs: Date.now() - startedAt
+          durationMs: Date.now() - startedAt,
+          stdoutBytes,
+          stderrBytes,
+          terminationSignal: signal
         })
         return
       }
@@ -346,7 +371,10 @@ const executeScriptProcess = async (
         stdout,
         stderr,
         exitCode: 0,
-        durationMs: Date.now() - startedAt
+        durationMs: Date.now() - startedAt,
+        stdoutBytes,
+        stderrBytes,
+        terminationSignal: signal
       })
     })
   })
@@ -368,7 +396,14 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         maxOutputBytes: resolveScriptMaxOutputBytes(),
         maxSourceBytes: resolveScriptMaxSourceBytes(),
         sourceBytes,
-        allowedEnvKeys: resolveScriptEnvAllowlist()
+        allowedEnvKeys: resolveScriptEnvAllowlist(),
+        runtimeCommand: null,
+        runtimeArgs: [],
+        stdoutBytes: 0,
+        stderrBytes: 0,
+        totalOutputBytes: 0,
+        terminationSignal: null,
+        policyTriggered: 'none'
       }
       return {
         status: 'failed',
@@ -395,9 +430,17 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       maxOutputBytes,
       maxSourceBytes,
       sourceBytes,
-      allowedEnvKeys: [...envAllowlist]
+      allowedEnvKeys: [...envAllowlist],
+      runtimeCommand: null,
+      runtimeArgs: [],
+      stdoutBytes: 0,
+      stderrBytes: 0,
+      totalOutputBytes: 0,
+      terminationSignal: null,
+      policyTriggered: 'none'
     }
     if (sourceBytes > maxSourceBytes) {
+      metadata.policyTriggered = 'source-size'
       return {
         status: 'failed',
         errorCode: 'policy-violation',
@@ -422,15 +465,33 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       )
       await writeRunnableScript(tempDirectory, language, context.definition.instruction)
       const runtime = resolveScriptBinaryByLanguage(language)
+      metadata.runtimeCommand = runtime.command
+      metadata.runtimeArgs = [...runtime.args]
+      console.info(
+        `[workflow-script-sandbox] provider=${metadata.providerId} phase=execute-start`
+        + ` command=${runtime.command} args=${runtime.args.join(' ') || '(none)'}`
+      )
       const executionResult = await executeScriptProcess(runtime.command, runtime.args, {
         cwd: tempDirectory,
         timeoutMs,
         maxOutputBytes,
         envAllowlist
       })
+      metadata.stdoutBytes = executionResult.stdoutBytes
+      metadata.stderrBytes = executionResult.stderrBytes
+      metadata.totalOutputBytes = executionResult.stdoutBytes + executionResult.stderrBytes
+      metadata.terminationSignal = executionResult.terminationSignal
+      if (executionResult.status === 'failed' && executionResult.errorCode === 'policy-violation') {
+        metadata.policyTriggered = 'output-size'
+      }
       console.info(
         `[workflow-script-sandbox] provider=${metadata.providerId} phase=teardown`
         + ` status=${executionResult.status} durationMs=${executionResult.durationMs}`
+        + ` stdoutBytes=${executionResult.stdoutBytes} stderrBytes=${executionResult.stderrBytes}`
+        + ` signal=${executionResult.terminationSignal ?? '(none)'}`
+        + (executionResult.status === 'failed'
+          ? ` errorCode=${executionResult.errorCode}`
+          : '')
       )
       return {
         ...executionResult,

--- a/server/utils/workflow-script-sandbox.ts
+++ b/server/utils/workflow-script-sandbox.ts
@@ -71,6 +71,7 @@ export type WorkflowScriptExecutionMetadata = {
   terminationSignal: NodeJS.Signals | null
   terminationScope: 'none' | 'process' | 'process-group'
   policyTriggered: 'none' | 'source-size' | 'output-size'
+  failurePhase: 'none' | 'prepare' | 'execute'
 }
 
 export type WorkflowScriptSandboxProvider = {
@@ -430,7 +431,8 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         totalOutputBytes: 0,
         terminationSignal: null,
         terminationScope: 'none',
-        policyTriggered: 'none'
+        policyTriggered: 'none',
+        failurePhase: 'none'
       }
       return {
         status: 'failed',
@@ -465,7 +467,8 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       totalOutputBytes: 0,
       terminationSignal: null,
       terminationScope: 'none',
-      policyTriggered: 'none'
+      policyTriggered: 'none',
+      failurePhase: 'none'
     }
     if (sourceBytes > maxSourceBytes) {
       metadata.policyTriggered = 'source-size'
@@ -483,6 +486,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       }
     }
     const tempDirectory = await mkdtemp(join(tmpdir(), 'corazon-workflow-script-'))
+    let executionPhase: 'prepare' | 'execute' = 'prepare'
     try {
       console.info(
         `[workflow-script-sandbox] provider=${metadata.providerId} phase=prepare`
@@ -495,6 +499,7 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       const runtime = resolveScriptBinaryByLanguage(language)
       metadata.runtimeCommand = runtime.command
       metadata.runtimeArgs = [...runtime.args]
+      executionPhase = 'execute'
       console.info(
         `[workflow-script-sandbox] provider=${metadata.providerId} phase=execute-start`
         + ` command=${runtime.command} args=${runtime.args.join(' ') || '(none)'}`
@@ -513,6 +518,9 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
       if (executionResult.status === 'failed' && executionResult.errorCode === 'policy-violation') {
         metadata.policyTriggered = 'output-size'
       }
+      if (executionResult.status === 'failed' && executionResult.errorCode === 'provider-error') {
+        metadata.failurePhase = 'execute'
+      }
       console.info(
         `[workflow-script-sandbox] provider=${metadata.providerId} phase=teardown`
         + ` status=${executionResult.status} durationMs=${executionResult.durationMs}`
@@ -528,10 +536,17 @@ const localScriptSandboxProvider: WorkflowScriptSandboxProvider = {
         metadata
       }
     } catch (error) {
+      metadata.failurePhase = executionPhase
+      const message = formatProviderFailureMessage(language, error)
+      console.warn(
+        `[workflow-script-sandbox] provider=${metadata.providerId} phase=teardown`
+        + ' status=failed errorCode=provider-error'
+        + ` failurePhase=${metadata.failurePhase} message=${message}`
+      )
       return {
         status: 'failed',
         errorCode: 'provider-error',
-        errorMessage: formatProviderFailureMessage(language, error),
+        errorMessage: message,
         stdout: '',
         stderr: '',
         exitCode: null,

--- a/templates/skills/manage-workflows/SKILL.md
+++ b/templates/skills/manage-workflows/SKILL.md
@@ -23,6 +23,7 @@ Each workflow file must be Markdown with YAML frontmatter.
 ---
 name: Hello Workflow
 description: Prints exactly one configured greeting line on each run.
+language: markdown
 on:
   interval: 2m
   workflow-dispatch: true
@@ -35,6 +36,7 @@ On each run, output exactly one assistant message: "Hello".
 ## Frontmatter Rules
 - `name`: English 2~3 words only. Example: `Hello Workflow`, `Daily Report Sender`.
 - `description`: one-sentence summary of actual behavior.
+- `language`: optional execution mode (`markdown` default, `typescript`, `python`).
 - `on`: trigger config
   - `schedule`: 5-field cron
   - `interval`: `{number}{s|m|h}` such as `120s`, `60m`, `2h`
@@ -43,6 +45,7 @@ On each run, output exactly one assistant message: "Hello".
 - `skills`: list of skill names.
 - Use only one time trigger at a time (`schedule`, `interval`, or `rrule`).
 - If no time trigger is configured, `workflow-dispatch: true` is required.
+- `language: typescript` and `language: python` are schema-valid, but runtime execution stays blocked until sandbox script runner support is implemented. Use `markdown` for runnable workflows today.
 
 ## Instruction Writing Principles
 - Do not write meta instructions such as "create/update a workflow"; write the **actual run-time behavior**.

--- a/types/workflow.ts
+++ b/types/workflow.ts
@@ -44,6 +44,7 @@ export type WorkflowRunSummary = {
   sessionThreadId: string | null
   sessionFilePath: string | null
   errorMessage: string | null
+  metadata: Record<string, unknown> | null
 }
 
 export type WorkflowRunHistoryMessage = {

--- a/types/workflow.ts
+++ b/types/workflow.ts
@@ -1,4 +1,5 @@
 export type WorkflowTriggerType = 'schedule' | 'interval' | 'rrule' | 'workflow-dispatch'
+export type WorkflowLanguage = 'markdown' | 'typescript' | 'python'
 
 export type WorkflowTriggerConfig = {
   'schedule'?: string
@@ -10,6 +11,7 @@ export type WorkflowTriggerConfig = {
 export type WorkflowFrontmatter = {
   name: string
   description: string
+  language: WorkflowLanguage
   on: WorkflowTriggerConfig
   skills: string[]
 }
@@ -86,6 +88,7 @@ export type WorkflowTriggerGuessResponse = {
 export type WorkflowUpsertRequest = {
   name: string
   description: string
+  language: WorkflowLanguage
   instruction: string
   skills: string[]
   triggerType: 'schedule' | 'interval' | 'rrule' | null


### PR DESCRIPTION
## Summary
- add `language` frontmatter support (`markdown`/`typescript`/`python`) to workflow types, parsing, serialization, request handling, and workflow API contracts
- make native `manageWorkflow` tool language-aware for `create`/`update`/`list`/`inspect`
- preserve non-`markdown` instruction bodies correctly in create/update/apply-text flows
- route `typescript`/`python` workflows through a script-sandbox provider abstraction with a runnable local provider
- align dispatch behavior for both manual runs and time triggers across all supported workflow languages
- map script-provider failure/timeout/unsupported cases to stable workflow run statuses and API error responses
- add workflow language regression smoke coverage (including script execution + timeout semantics)
- document runtime configuration for script sandbox execution

## Why this slice
Issue #88 started as schema/tooling groundwork. During follow-up maintenance this PR absorbed the critical runtime path needed to make script-language workflows actually executable with safe defaults and predictable failure behavior.

## Validation
- `pnpm workflows:language:smoke`
- `pnpm lint`
- `pnpm typecheck`

## Remaining follow-up
- add managed sandbox provider adapters (for example E2B/Daytona-class backends) behind the existing provider interface
- harden resource/isolation policy and provider-level observability for multi-tenant runtime use

Closes #88
Closes #90