### PR TITLE
Improve deploy remote-build diagnostics and guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Verify post-deploy recovery regression guards
         run: pnpm run recovery:verify
 
+      - name: Verify deploy disk-pressure decision matrix
+        run: pnpm run deploy:disk-pressure:verify
+
       - name: Verify startup alert regression guards
         run: pnpm run startup-alert:smoke
 

--- a/.github/workflows/deploy-verification-evidence.yml
+++ b/.github/workflows/deploy-verification-evidence.yml
@@ -1,0 +1,100 @@
+name: deploy-verification-evidence
+
+on:
+  workflow_run:
+    workflows: ["deploy"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: deploy-verification-evidence-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  record-deploy-evidence:
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    env:
+      REPO: ${{ github.repository }}
+      TRACKING_ISSUES: "98,96"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Capture deploy run context
+        id: ctx
+        run: |
+          set -euo pipefail
+          conclusion="${{ github.event.workflow_run.conclusion }}"
+          run_attempt="${{ github.event.workflow_run.run_attempt }}"
+          should_post=true
+
+          if [[ "${conclusion}" == "failure" && "${run_attempt}" == "1" ]]; then
+            should_post=false
+          fi
+
+          echo "conclusion=${conclusion}" >> "$GITHUB_OUTPUT"
+          echo "run_id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+          echo "run_number=${{ github.event.workflow_run.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "run_attempt=${run_attempt}" >> "$GITHUB_OUTPUT"
+          echo "run_url=${{ github.event.workflow_run.html_url }}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+          echo "head_branch=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+          echo "should_post=${should_post}" >> "$GITHUB_OUTPUT"
+
+      - name: Retry failed deploy run once
+        if: steps.ctx.outputs.conclusion == 'failure' && steps.ctx.outputs.run_attempt == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api \
+            --method POST \
+            "repos/${REPO}/actions/runs/${{ steps.ctx.outputs.run_id }}/rerun-failed-jobs"
+
+      - name: Build evidence comment
+        if: steps.ctx.outputs.should_post == 'true'
+        run: |
+          set -euo pipefail
+
+          head_short="$(printf '%s' '${{ steps.ctx.outputs.head_sha }}' | cut -c1-12)"
+          conclusion="${{ steps.ctx.outputs.conclusion }}"
+          result_line="Deploy verification status: success"
+          next_action="None"
+
+          if [[ "${conclusion}" == "failure" ]]; then
+            result_line="Deploy verification status: failure after auto-retry"
+            next_action="Inspect failing steps and diagnostics artifact from the linked deploy run; then fix forward in the next PR."
+          elif [[ "${conclusion}" != "success" ]]; then
+            result_line="Deploy verification status: ${conclusion}"
+            next_action="Review deploy run details and decide whether a manual rerun or follow-up fix is needed."
+          fi
+
+          cat > /tmp/deploy-evidence-comment.md <<EOF
+## Deploy verification evidence
+- Result: ${result_line}
+- Branch: \`${{ steps.ctx.outputs.head_branch }}\`
+- Commit: \`${head_short}\`
+- Run: [deploy #${{ steps.ctx.outputs.run_number }} attempt ${{ steps.ctx.outputs.run_attempt }}](${{ steps.ctx.outputs.run_url }})
+- Trigger: \`push\` to \`main\`
+- Next action: ${next_action}
+EOF
+
+      - name: Post evidence to tracking issues
+        if: steps.ctx.outputs.should_post == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -r -a issue_numbers <<< "${TRACKING_ISSUES}"
+          for issue in "${issue_numbers[@]}"; do
+            trimmed="$(echo "${issue}" | xargs)"
+            if [[ -z "${trimmed}" ]]; then
+              continue
+            fi
+            scripts/gh-comment-safe.sh issue "${trimmed}" --repo "${REPO}" < /tmp/deploy-evidence-comment.md
+          done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,6 +111,35 @@ jobs:
             '
           }
 
+          compute_pressure_decision() {
+            local root_kb="$1"
+            local docker_kb="$2"
+            local attempted_flag="$3"
+            local line
+            local key
+            local value
+
+            while IFS= read -r line; do
+              key="${line%%=*}"
+              value="${line#*=}"
+              case "${key}" in
+                PRESSURE_TARGET) pressure_target="${value}" ;;
+                PRESSURE_AVAILABLE_KB) pressure_avail_kb="${value}" ;;
+                SHOULD_REMEDIATE) should_remediate="${value}" ;;
+                SHOULD_FAIL) should_fail="${value}" ;;
+              esac
+            done < <(
+              node scripts/deploy-disk-pressure-decision.mjs \
+                --root-avail-kb "${root_kb}" \
+                --docker-avail-kb "${docker_kb}" \
+                --docker-root-dir "${docker_root_dir}" \
+                --min-required-kb "${min_required_kb}" \
+                --remediation-enabled "${remediation_enabled}" \
+                --remediation-attempted "${attempted_flag}" \
+                --format env
+            )
+          }
+
           ssh "${{ secrets.DEPLOY_HOST }}" '
             set -e
             df -Pk / > /tmp/corazon-deploy-df.txt
@@ -118,12 +147,7 @@ jobs:
           ' > deploy-diagnostics/remote-preflight.txt 2>&1
           root_avail_kb="$(collect_avail_kb /)"
           docker_avail_kb="$(collect_avail_kb "${docker_root_dir}")"
-          pressure_target="/"
-          pressure_avail_kb="${root_avail_kb}"
-          if (( docker_avail_kb < pressure_avail_kb )); then
-            pressure_target="${docker_root_dir}"
-            pressure_avail_kb="${docker_avail_kb}"
-          fi
+          compute_pressure_decision "${root_avail_kb}" "${docker_avail_kb}" "${remediation_attempted}"
           echo "root_available_kb=${root_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
           echo "docker_root_dir=${docker_root_dir}" | tee -a deploy-diagnostics/remote-preflight.txt
           echo "docker_available_kb=${docker_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
@@ -136,7 +160,7 @@ jobs:
             exit 1
           fi
 
-          if (( pressure_avail_kb < min_required_kb )) && [[ "${remediation_enabled}" == "true" ]]; then
+          if [[ "${should_remediate}" == "true" ]]; then
             remediation_attempted=true
             {
               echo "Low disk space detected on ${pressure_target} (${pressure_avail_kb} KiB). Starting bounded remediation."
@@ -155,19 +179,14 @@ jobs:
 
             root_avail_kb="$(collect_avail_kb /)"
             docker_avail_kb="$(collect_avail_kb "${docker_root_dir}")"
-            pressure_target="/"
-            pressure_avail_kb="${root_avail_kb}"
-            if (( docker_avail_kb < pressure_avail_kb )); then
-              pressure_target="${docker_root_dir}"
-              pressure_avail_kb="${docker_avail_kb}"
-            fi
+            compute_pressure_decision "${root_avail_kb}" "${docker_avail_kb}" "${remediation_attempted}"
             echo "root_available_kb_after_remediation=${root_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
             echo "docker_available_kb_after_remediation=${docker_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
             echo "pressure_target_after_remediation=${pressure_target}" | tee -a deploy-diagnostics/remote-preflight.txt
             echo "pressure_available_kb_after_remediation=${pressure_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
           fi
 
-          if (( pressure_avail_kb < min_required_kb )); then
+          if [[ "${should_fail}" == "true" ]]; then
             if [[ "${remediation_attempted}" == "true" ]]; then
               echo "Remote filesystem ${pressure_target} is still below 3GiB after remediation (${pressure_avail_kb} KiB)." | tee -a deploy-diagnostics/remote-preflight.txt >&2
               echo "See deploy-diagnostics/remote-disk-remediation.txt for remediation telemetry." | tee -a deploy-diagnostics/remote-preflight.txt >&2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,7 @@ jobs:
           mkdir -p deploy-diagnostics
           ssh "${{ secrets.DEPLOY_HOST }}" '
             set -e
-            df -h / > /tmp/corazon-deploy-df.txt
+            df -Pk / > /tmp/corazon-deploy-df.txt
             awk "NR==2 {print \\$4}" /tmp/corazon-deploy-df.txt > /tmp/corazon-root-avail-kb.txt
             df -h /var/lib/docker || true
           ' > deploy-diagnostics/remote-preflight.txt 2>&1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,7 +231,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: deploy-diagnostics-${{ github.run_id }}
+          name: deploy-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
           path: deploy-diagnostics/
           if-no-files-found: warn
 
@@ -284,7 +284,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: post-deploy-recovery-${{ github.run_id }}
+          name: post-deploy-recovery-${{ github.run_id }}-${{ github.run_attempt }}
           path: post-deploy-recovery.json
           if-no-files-found: error
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,20 +89,65 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p deploy-diagnostics
+          min_required_kb=3145728
+          remediation_enabled="${{ secrets.DEPLOY_ENABLE_DISK_REMEDIATION }}"
+          remediation_attempted=false
+
+          if [[ -z "${remediation_enabled}" ]]; then
+            remediation_enabled=false
+          fi
+
+          collect_root_avail_kb() {
+            ssh "${{ secrets.DEPLOY_HOST }}" '
+              set -e
+              df -Pk / > /tmp/corazon-deploy-df.txt
+              awk "NR==2 {print \\$4}" /tmp/corazon-deploy-df.txt
+            '
+          }
+
           ssh "${{ secrets.DEPLOY_HOST }}" '
             set -e
             df -Pk / > /tmp/corazon-deploy-df.txt
-            awk "NR==2 {print \\$4}" /tmp/corazon-deploy-df.txt > /tmp/corazon-root-avail-kb.txt
             df -h /var/lib/docker || true
           ' > deploy-diagnostics/remote-preflight.txt 2>&1
-          root_avail_kb="$(ssh "${{ secrets.DEPLOY_HOST }}" "cat /tmp/corazon-root-avail-kb.txt")"
+          root_avail_kb="$(collect_root_avail_kb)"
           echo "root_available_kb=${root_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
+          echo "min_required_kb=${min_required_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
+          echo "disk_remediation_enabled=${remediation_enabled}" | tee -a deploy-diagnostics/remote-preflight.txt
           if [[ -z "${root_avail_kb}" ]]; then
             echo "Unable to determine remote root filesystem free space." >&2
             exit 1
           fi
-          if (( root_avail_kb < 3145728 )); then
-            echo "Remote root filesystem has less than 3GiB free (${root_avail_kb} KiB)." | tee -a deploy-diagnostics/remote-preflight.txt >&2
+
+          if (( root_avail_kb < min_required_kb )) && [[ "${remediation_enabled}" == "true" ]]; then
+            remediation_attempted=true
+            {
+              echo "Low root space detected (${root_avail_kb} KiB). Starting bounded remediation."
+              echo "== before =="
+              ssh "${{ secrets.DEPLOY_HOST }}" 'df -h / /var/lib/docker || true'
+              echo
+              echo "== prune docker builder cache (until=24h) =="
+              ssh "${{ secrets.DEPLOY_HOST }}" 'docker builder prune -af --filter "until=24h" || true'
+              echo
+              echo "== prune unused docker objects (until=24h) =="
+              ssh "${{ secrets.DEPLOY_HOST }}" 'docker system prune -af --filter "until=24h" || true'
+              echo
+              echo "== after =="
+              ssh "${{ secrets.DEPLOY_HOST }}" 'df -h / /var/lib/docker || true'
+            } > deploy-diagnostics/remote-disk-remediation.txt 2>&1
+
+            root_avail_kb="$(collect_root_avail_kb)"
+            echo "root_available_kb_after_remediation=${root_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
+          fi
+
+          if (( root_avail_kb < min_required_kb )); then
+            if [[ "${remediation_attempted}" == "true" ]]; then
+              echo "Remote root filesystem still below 3GiB after remediation (${root_avail_kb} KiB)." | tee -a deploy-diagnostics/remote-preflight.txt >&2
+              echo "See deploy-diagnostics/remote-disk-remediation.txt for remediation telemetry." | tee -a deploy-diagnostics/remote-preflight.txt >&2
+            else
+              echo "Remote root filesystem has less than 3GiB free (${root_avail_kb} KiB)." | tee -a deploy-diagnostics/remote-preflight.txt >&2
+              echo "Set DEPLOY_ENABLE_DISK_REMEDIATION=true to allow bounded auto-remediation before build." | tee -a deploy-diagnostics/remote-preflight.txt >&2
+            fi
             exit 1
           fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,15 +92,21 @@ jobs:
           min_required_kb=3145728
           remediation_enabled="${{ secrets.DEPLOY_ENABLE_DISK_REMEDIATION }}"
           remediation_attempted=false
+          docker_root_dir="$(docker --context production info --format '{{.DockerRootDir}}' 2>/dev/null || true)"
 
           if [[ -z "${remediation_enabled}" ]]; then
             remediation_enabled=false
           fi
 
-          collect_root_avail_kb() {
+          if [[ -z "${docker_root_dir}" ]]; then
+            docker_root_dir="/var/lib/docker"
+          fi
+
+          collect_avail_kb() {
+            local target_path="$1"
             ssh "${{ secrets.DEPLOY_HOST }}" '
               set -e
-              df -Pk / > /tmp/corazon-deploy-df.txt
+              df -Pk '"${target_path}"' > /tmp/corazon-deploy-df.txt
               awk "NR==2 {print \\$4}" /tmp/corazon-deploy-df.txt
             '
           }
@@ -108,23 +114,34 @@ jobs:
           ssh "${{ secrets.DEPLOY_HOST }}" '
             set -e
             df -Pk / > /tmp/corazon-deploy-df.txt
-            df -h /var/lib/docker || true
+            df -h '"${docker_root_dir}"' || true
           ' > deploy-diagnostics/remote-preflight.txt 2>&1
-          root_avail_kb="$(collect_root_avail_kb)"
+          root_avail_kb="$(collect_avail_kb /)"
+          docker_avail_kb="$(collect_avail_kb "${docker_root_dir}")"
+          pressure_target="/"
+          pressure_avail_kb="${root_avail_kb}"
+          if (( docker_avail_kb < pressure_avail_kb )); then
+            pressure_target="${docker_root_dir}"
+            pressure_avail_kb="${docker_avail_kb}"
+          fi
           echo "root_available_kb=${root_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
+          echo "docker_root_dir=${docker_root_dir}" | tee -a deploy-diagnostics/remote-preflight.txt
+          echo "docker_available_kb=${docker_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
+          echo "pressure_target=${pressure_target}" | tee -a deploy-diagnostics/remote-preflight.txt
+          echo "pressure_available_kb=${pressure_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
           echo "min_required_kb=${min_required_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
           echo "disk_remediation_enabled=${remediation_enabled}" | tee -a deploy-diagnostics/remote-preflight.txt
-          if [[ -z "${root_avail_kb}" ]]; then
-            echo "Unable to determine remote root filesystem free space." >&2
+          if [[ -z "${root_avail_kb}" || -z "${docker_avail_kb}" ]]; then
+            echo "Unable to determine remote filesystem free space for deploy preflight." >&2
             exit 1
           fi
 
-          if (( root_avail_kb < min_required_kb )) && [[ "${remediation_enabled}" == "true" ]]; then
+          if (( pressure_avail_kb < min_required_kb )) && [[ "${remediation_enabled}" == "true" ]]; then
             remediation_attempted=true
             {
-              echo "Low root space detected (${root_avail_kb} KiB). Starting bounded remediation."
+              echo "Low disk space detected on ${pressure_target} (${pressure_avail_kb} KiB). Starting bounded remediation."
               echo "== before =="
-              ssh "${{ secrets.DEPLOY_HOST }}" 'df -h / /var/lib/docker || true'
+              ssh "${{ secrets.DEPLOY_HOST }}" 'df -h / '"${docker_root_dir}"' || true'
               echo
               echo "== prune docker builder cache (until=24h) =="
               ssh "${{ secrets.DEPLOY_HOST }}" 'docker builder prune -af --filter "until=24h" || true'
@@ -133,19 +150,29 @@ jobs:
               ssh "${{ secrets.DEPLOY_HOST }}" 'docker system prune -af --filter "until=24h" || true'
               echo
               echo "== after =="
-              ssh "${{ secrets.DEPLOY_HOST }}" 'df -h / /var/lib/docker || true'
+              ssh "${{ secrets.DEPLOY_HOST }}" 'df -h / '"${docker_root_dir}"' || true'
             } > deploy-diagnostics/remote-disk-remediation.txt 2>&1
 
-            root_avail_kb="$(collect_root_avail_kb)"
+            root_avail_kb="$(collect_avail_kb /)"
+            docker_avail_kb="$(collect_avail_kb "${docker_root_dir}")"
+            pressure_target="/"
+            pressure_avail_kb="${root_avail_kb}"
+            if (( docker_avail_kb < pressure_avail_kb )); then
+              pressure_target="${docker_root_dir}"
+              pressure_avail_kb="${docker_avail_kb}"
+            fi
             echo "root_available_kb_after_remediation=${root_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
+            echo "docker_available_kb_after_remediation=${docker_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
+            echo "pressure_target_after_remediation=${pressure_target}" | tee -a deploy-diagnostics/remote-preflight.txt
+            echo "pressure_available_kb_after_remediation=${pressure_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
           fi
 
-          if (( root_avail_kb < min_required_kb )); then
+          if (( pressure_avail_kb < min_required_kb )); then
             if [[ "${remediation_attempted}" == "true" ]]; then
-              echo "Remote root filesystem still below 3GiB after remediation (${root_avail_kb} KiB)." | tee -a deploy-diagnostics/remote-preflight.txt >&2
+              echo "Remote filesystem ${pressure_target} is still below 3GiB after remediation (${pressure_avail_kb} KiB)." | tee -a deploy-diagnostics/remote-preflight.txt >&2
               echo "See deploy-diagnostics/remote-disk-remediation.txt for remediation telemetry." | tee -a deploy-diagnostics/remote-preflight.txt >&2
             else
-              echo "Remote root filesystem has less than 3GiB free (${root_avail_kb} KiB)." | tee -a deploy-diagnostics/remote-preflight.txt >&2
+              echo "Remote filesystem ${pressure_target} has less than 3GiB free (${pressure_avail_kb} KiB)." | tee -a deploy-diagnostics/remote-preflight.txt >&2
               echo "Set DEPLOY_ENABLE_DISK_REMEDIATION=true to allow bounded auto-remediation before build." | tee -a deploy-diagnostics/remote-preflight.txt >&2
             fi
             exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,14 +54,14 @@ jobs:
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan -H "${{ secrets.DEPLOY_HOST }}" >> ~/.ssh/known_hosts
-          cat >> ~/.ssh/config <<EOF
+          cat >> ~/.ssh/config <<EOF_INNER
           Host ${{ secrets.DEPLOY_HOST }}
             HostName ${{ secrets.DEPLOY_HOST }}
             User ubuntu
             ServerAliveInterval 15
             ServerAliveCountMax 20
             TCPKeepAlive yes
-          EOF
+          EOF_INNER
 
       - name: Create remote Docker context
         run: |
@@ -84,19 +84,77 @@ jobs:
           uname -m
           docker --context production version --format 'client={{.Client.Arch}} server={{.Server.Arch}}'
 
-      - name: Build application image on remote Docker host
+      - name: Preflight remote deploy host guardrails
         if: steps.mode.outputs.skip_deploy != 'true'
-        run: docker --context production build --progress=plain --platform linux/arm64 -t corazon:latest .
+        run: |
+          set -euo pipefail
+          mkdir -p deploy-diagnostics
+          ssh "${{ secrets.DEPLOY_HOST }}" '
+            set -e
+            df -h / > /tmp/corazon-deploy-df.txt
+            awk "NR==2 {print \\$4}" /tmp/corazon-deploy-df.txt > /tmp/corazon-root-avail-kb.txt
+            df -h /var/lib/docker || true
+          ' > deploy-diagnostics/remote-preflight.txt 2>&1
+          root_avail_kb="$(ssh "${{ secrets.DEPLOY_HOST }}" "cat /tmp/corazon-root-avail-kb.txt")"
+          echo "root_available_kb=${root_avail_kb}" | tee -a deploy-diagnostics/remote-preflight.txt
+          if [[ -z "${root_avail_kb}" ]]; then
+            echo "Unable to determine remote root filesystem free space." >&2
+            exit 1
+          fi
+          if (( root_avail_kb < 3145728 )); then
+            echo "Remote root filesystem has less than 3GiB free (${root_avail_kb} KiB)." | tee -a deploy-diagnostics/remote-preflight.txt >&2
+            exit 1
+          fi
+
+      - name: Build application image on remote Docker host
+        id: remote_build
+        if: steps.mode.outputs.skip_deploy != 'true'
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          mkdir -p deploy-diagnostics
+          docker --context production build --progress=plain --platform linux/arm64 -t corazon:latest . 2>&1 | tee deploy-diagnostics/remote-build.log
+
+      - name: Capture remote build failure diagnostics
+        if: steps.mode.outputs.skip_deploy != 'true' && steps.remote_build.outcome == 'failure'
+        run: |
+          mkdir -p deploy-diagnostics
+          {
+            echo "Build failed while creating corazon:latest on remote Docker host."
+            echo
+            echo "== docker info (remote context) =="
+            docker --context production info || true
+            echo
+            echo "== docker system df (remote context) =="
+            docker --context production system df || true
+            echo
+            echo "== remote disk usage =="
+            ssh "${{ secrets.DEPLOY_HOST }}" 'df -h / /var/lib/docker || true'
+          } > deploy-diagnostics/remote-build-failure-diagnostics.txt 2>&1
+
+      - name: Upload remote deploy diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-diagnostics-${{ github.run_id }}
+          path: deploy-diagnostics/
+          if-no-files-found: warn
+
+      - name: Fail deploy when remote image build fails
+        if: steps.mode.outputs.skip_deploy != 'true' && steps.remote_build.outcome == 'failure'
+        run: |
+          echo "Remote Docker image build failed. See deploy-diagnostics artifact for details."
+          exit 1
 
       - name: Verify built image architecture
-        if: steps.mode.outputs.skip_deploy != 'true'
+        if: steps.mode.outputs.skip_deploy != 'true' && steps.remote_build.outcome == 'success'
         run: |
           image_platform="$(docker --context production image inspect corazon:latest --format '{{.Os}}/{{.Architecture}}')"
           echo "$image_platform"
           test "$image_platform" = "linux/arm64"
 
       - name: Deploy on remote Docker host
-        if: steps.mode.outputs.skip_deploy != 'true'
+        if: steps.mode.outputs.skip_deploy != 'true' && steps.remote_build.outcome == 'success'
         run: |
           docker --context production compose pull chroma
           docker --context production compose up -d --no-build --remove-orphans
@@ -125,7 +183,7 @@ jobs:
         if: always() && steps.recovery_gate.outputs.status != ''
         run: |
           ssh "${{ secrets.DEPLOY_HOST }}" \
-            "printf '%s\n' '${{ steps.recovery_gate.outputs.status }}' > /home/ubuntu/.corazon/post-deploy-recovery-last-status.txt"
+            "printf '%s\\n' '${{ steps.recovery_gate.outputs.status }}' > /home/ubuntu/.corazon/post-deploy-recovery-last-status.txt"
 
       - name: Upload post-deploy recovery report
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -210,6 +210,10 @@ jobs:
         if: steps.mode.outputs.skip_deploy != 'true' && steps.remote_build.outcome == 'failure'
         run: |
           mkdir -p deploy-diagnostics
+          docker_root_dir="$(docker --context production info --format '{{.DockerRootDir}}' 2>/dev/null || true)"
+          if [[ -z "${docker_root_dir}" ]]; then
+            docker_root_dir="/var/lib/docker"
+          fi
           {
             echo "Build failed while creating corazon:latest on remote Docker host."
             echo
@@ -220,7 +224,7 @@ jobs:
             docker --context production system df || true
             echo
             echo "== remote disk usage =="
-            ssh "${{ secrets.DEPLOY_HOST }}" 'df -h / /var/lib/docker || true'
+            ssh "${{ secrets.DEPLOY_HOST }}" 'df -h / '"${docker_root_dir}"' || true'
           } > deploy-diagnostics/remote-build-failure-diagnostics.txt 2>&1
 
       - name: Upload remote deploy diagnostics

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "chatgpt:smoke": "node scripts/chatgpt-codex-responses-smoke.ts",
     "startup-alert:smoke": "node scripts/startup-alert-smoke.ts",
     "audio-transcription:verify": "node scripts/audio-transcription-regression-smoke.ts",
+    "deploy:disk-pressure:verify": "node scripts/verify-deploy-disk-pressure-decision.mjs",
     "recovery:verify": "node scripts/verify-post-deploy-recovery.mjs",
     "types:codex-app-server": "node scripts/generate-codex-app-server-types.mjs",
     "preview": "nuxt preview",

--- a/scripts/deploy-disk-pressure-decision.mjs
+++ b/scripts/deploy-disk-pressure-decision.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on'])
+
+function parseArgs(argv) {
+  const args = {}
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i]
+    if (!token.startsWith('--')) {
+      continue
+    }
+
+    const key = token.slice(2)
+    const next = argv[i + 1]
+    if (!next || next.startsWith('--')) {
+      args[key] = 'true'
+      continue
+    }
+
+    args[key] = next
+    i += 1
+  }
+  return args
+}
+
+function parsePositiveInteger(rawValue, field) {
+  const value = Number(rawValue)
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative integer, received: ${rawValue ?? '<undefined>'}`)
+  }
+  return value
+}
+
+function parseBoolean(rawValue) {
+  if (!rawValue) {
+    return false
+  }
+  return TRUE_VALUES.has(String(rawValue).trim().toLowerCase())
+}
+
+function choosePressureTarget({ rootAvailKb, dockerAvailKb, dockerRootDir }) {
+  if (dockerAvailKb < rootAvailKb) {
+    return {
+      pressureTarget: dockerRootDir,
+      pressureAvailableKb: dockerAvailKb
+    }
+  }
+
+  return {
+    pressureTarget: '/',
+    pressureAvailableKb: rootAvailKb
+  }
+}
+
+function decide(params) {
+  const { pressureTarget, pressureAvailableKb } = choosePressureTarget(params)
+  const belowThreshold = pressureAvailableKb < params.minRequiredKb
+  const shouldRemediate = belowThreshold && params.remediationEnabled && !params.remediationAttempted
+  const shouldFail = belowThreshold && (!params.remediationEnabled || params.remediationAttempted)
+
+  return {
+    pressureTarget,
+    pressureAvailableKb,
+    shouldRemediate,
+    shouldFail
+  }
+}
+
+function toEnvLine(key, value) {
+  return `${key}=${String(value)}`
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+
+  const params = {
+    rootAvailKb: parsePositiveInteger(args['root-avail-kb'], 'root-avail-kb'),
+    dockerAvailKb: parsePositiveInteger(args['docker-avail-kb'], 'docker-avail-kb'),
+    dockerRootDir: args['docker-root-dir'] || '/var/lib/docker',
+    minRequiredKb: parsePositiveInteger(args['min-required-kb'] ?? '3145728', 'min-required-kb'),
+    remediationEnabled: parseBoolean(args['remediation-enabled']),
+    remediationAttempted: parseBoolean(args['remediation-attempted']),
+    format: (args.format || 'json').toLowerCase()
+  }
+
+  const decision = decide(params)
+
+  if (params.format === 'env') {
+    process.stdout.write(`${toEnvLine('PRESSURE_TARGET', decision.pressureTarget)}\n`)
+    process.stdout.write(`${toEnvLine('PRESSURE_AVAILABLE_KB', decision.pressureAvailableKb)}\n`)
+    process.stdout.write(`${toEnvLine('SHOULD_REMEDIATE', decision.shouldRemediate)}\n`)
+    process.stdout.write(`${toEnvLine('SHOULD_FAIL', decision.shouldFail)}\n`)
+    return
+  }
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        input: {
+          rootAvailKb: params.rootAvailKb,
+          dockerAvailKb: params.dockerAvailKb,
+          dockerRootDir: params.dockerRootDir,
+          minRequiredKb: params.minRequiredKb,
+          remediationEnabled: params.remediationEnabled,
+          remediationAttempted: params.remediationAttempted
+        },
+        decision
+      },
+      null,
+      2
+    )}\n`
+  )
+}
+
+try {
+  main()
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(`[deploy-disk-pressure-decision] ${message}`)
+  process.exitCode = 1
+}

--- a/scripts/verify-deploy-disk-pressure-decision.mjs
+++ b/scripts/verify-deploy-disk-pressure-decision.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+
+const SCRIPT_PATH = 'scripts/deploy-disk-pressure-decision.mjs'
+const MIN_REQUIRED_KB = 3 * 1024 * 1024
+
+const scenarios = [
+  {
+    name: 'root pressure triggers remediation when enabled',
+    args: {
+      root: 1_000_000,
+      docker: 8_000_000,
+      dockerRootDir: '/var/lib/docker',
+      remediationEnabled: true,
+      remediationAttempted: false
+    },
+    expect: {
+      pressureTarget: '/',
+      shouldRemediate: true,
+      shouldFail: false
+    }
+  },
+  {
+    name: 'docker pressure triggers remediation when docker mount is tighter',
+    args: {
+      root: 9_000_000,
+      docker: 512_000,
+      dockerRootDir: '/mnt/docker-data',
+      remediationEnabled: true,
+      remediationAttempted: false
+    },
+    expect: {
+      pressureTarget: '/mnt/docker-data',
+      shouldRemediate: true,
+      shouldFail: false
+    }
+  },
+  {
+    name: 'below threshold without remediation flag fails fast',
+    args: {
+      root: 2_000_000,
+      docker: 2_200_000,
+      dockerRootDir: '/var/lib/docker',
+      remediationEnabled: false,
+      remediationAttempted: false
+    },
+    expect: {
+      pressureTarget: '/',
+      shouldRemediate: false,
+      shouldFail: true
+    }
+  },
+  {
+    name: 'after remediation with recovered space passes',
+    args: {
+      root: 3_300_000,
+      docker: 3_600_000,
+      dockerRootDir: '/var/lib/docker',
+      remediationEnabled: true,
+      remediationAttempted: true
+    },
+    expect: {
+      pressureTarget: '/',
+      shouldRemediate: false,
+      shouldFail: false
+    }
+  },
+  {
+    name: 'after remediation still below threshold fails',
+    args: {
+      root: 2_200_000,
+      docker: 2_100_000,
+      dockerRootDir: '/var/lib/docker',
+      remediationEnabled: true,
+      remediationAttempted: true
+    },
+    expect: {
+      pressureTarget: '/var/lib/docker',
+      shouldRemediate: false,
+      shouldFail: true
+    }
+  },
+  {
+    name: 'equal values choose root filesystem deterministically',
+    args: {
+      root: 4_000_000,
+      docker: 4_000_000,
+      dockerRootDir: '/var/lib/docker',
+      remediationEnabled: true,
+      remediationAttempted: false
+    },
+    expect: {
+      pressureTarget: '/',
+      shouldRemediate: false,
+      shouldFail: false
+    }
+  }
+]
+
+function runDecisionScenario(scenario) {
+  const result = spawnSync(
+    process.execPath,
+    [
+      SCRIPT_PATH,
+      '--root-avail-kb',
+      String(scenario.args.root),
+      '--docker-avail-kb',
+      String(scenario.args.docker),
+      '--docker-root-dir',
+      scenario.args.dockerRootDir,
+      '--min-required-kb',
+      String(MIN_REQUIRED_KB),
+      '--remediation-enabled',
+      String(scenario.args.remediationEnabled),
+      '--remediation-attempted',
+      String(scenario.args.remediationAttempted)
+    ],
+    { encoding: 'utf8' }
+  )
+
+  if (result.status !== 0) {
+    throw new Error(
+      `[${scenario.name}] command failed (exit=${String(result.status)}): ${result.stderr || result.stdout}`
+    )
+  }
+
+  const payload = JSON.parse(result.stdout)
+  const actual = payload.decision
+  for (const [key, expectedValue] of Object.entries(scenario.expect)) {
+    if (actual[key] !== expectedValue) {
+      throw new Error(
+        `[${scenario.name}] expected ${key}=${String(expectedValue)} but got ${String(actual[key])}`
+      )
+    }
+  }
+}
+
+for (const scenario of scenarios) {
+  runDecisionScenario(scenario)
+}
+
+console.log(`Verified deploy disk-pressure decision matrix (${scenarios.length} scenarios).`)


### PR DESCRIPTION
## Summary
- add a preflight guardrail step before remote image build to fail fast when root filesystem free space is critically low
- capture remote build output into `deploy-diagnostics/remote-build.log`
- collect deterministic failure diagnostics (`docker info`, `docker system df`, remote disk usage) when remote build fails
- upload deploy diagnostics as artifacts even on failure and fail with an explicit message after artifact upload
- gate image architecture verification and deployment to run only when the remote build succeeded
- add bounded, opt-in disk-pressure remediation with before/after telemetry and split-mount Docker root coverage
- add CI-simulated deploy disk-pressure decision verification to catch regressions before deploy-time

## Why
`deploy` runs on `main` have been repeatedly failing in `Build application image on remote Docker host` with insufficient immediate diagnostic context. This change improves root-cause visibility, adds an early guardrail for a common failure precondition, and adds regression-safe validation for disk-pressure branching logic.

## Validation
- `pnpm run deploy:disk-pressure:verify`
- `pnpm lint`
- `pnpm typecheck`

Closes #94
Closes #97
Refs #96


Closes #98