### PR TITLE
fix: restore deploy preflight disk parsing in remote guardrail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,7 +107,7 @@ jobs:
             ssh "${{ secrets.DEPLOY_HOST }}" '
               set -e
               df -Pk '"${target_path}"' > /tmp/corazon-deploy-df.txt
-              awk "NR==2 {print \\$4}" /tmp/corazon-deploy-df.txt
+              tail -n +2 /tmp/corazon-deploy-df.txt | head -n 1 | tr -s " " | cut -d " " -f4
             '
           }
 


### PR DESCRIPTION
## Summary
- fix the remote preflight free-space parser to avoid shell-escaping breakage in the SSH `awk` invocation
- keep the behavior unchanged (`available_kb` extraction from `df -Pk`) while using a safer parse pipeline

## Why
The first deploy run after merging #95 failed in `Preflight remote deploy host guardrails` due to an `awk` parse error (`backslash not last character on line`), which prevented the intended disk-pressure fail-fast/remediation flow from executing.

## Validation
- `pnpm run deploy:disk-pressure:verify`
- `pnpm lint`
- `pnpm typecheck`

## Evidence
- Failed run: https://github.com/comfuture/corazon/actions/runs/24979502576

Refs #96
