### PR TITLE
fix(actions): restore deploy-verification-evidence workflow compilation

### DIFF
--- a/.github/workflows/deploy-verification-evidence.yml
+++ b/.github/workflows/deploy-verification-evidence.yml
@@ -11,12 +11,12 @@ permissions:
   issues: write
 
 concurrency:
-  group: deploy-verification-evidence-${{ github.event.workflow_run.id }}
+  group: deploy-verification-evidence-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
   record-deploy-evidence:
-    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main'
+    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
     env:
       REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- switch workflow-level `concurrency.group` to `github.run_id` instead of `github.event.workflow_run.id`
- make the job-level `if` expression explicit with `${{ ... }}` to avoid parser ambiguity on `workflow_run`
- keep behavior the same: only record evidence for `push` deploy runs on `main`

## Validation
- `pnpm lint`
- `pnpm typecheck`

## Expected outcome
`deploy-verification-evidence` should materialize jobs instead of failing at 0s with workflow-file compilation errors.

Closes #100
