### PR TITLE
fix(actions): harden deploy-verification-evidence compile guards

### DIFF
--- a/.github/workflows/deploy-verification-evidence.yml
+++ b/.github/workflows/deploy-verification-evidence.yml
@@ -10,13 +10,9 @@ permissions:
   contents: read
   issues: write
 
-concurrency:
-  group: deploy-verification-evidence-${{ github.run_id }}
-  cancel-in-progress: false
-
 jobs:
   record-deploy-evidence:
-    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
     env:
       REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- remove workflow-level `concurrency` expression from `deploy-verification-evidence` to avoid pre-job workflow compilation failures
- harden the job gate with an explicit `github.event_name == 'workflow_run'` guard before accessing `github.event.workflow_run.*`
- keep the original behavior target (`push` deploy runs on `main`) unchanged

## Why
The merge of PR #101 still produced an immediate 0s failure (`run 24994357044`) with no materialized jobs, so issue #100 remained unresolved in practice.

## Validation
- `pnpm lint`
- `pnpm typecheck`

## Expected outcome
Next `deploy-verification-evidence` execution should materialize at least one job instead of failing at workflow compilation stage.

Closes #100
