### PR TITLE
fix(actions): repair deploy evidence workflow yaml syntax

### DIFF
--- a/.github/workflows/deploy-verification-evidence.yml
+++ b/.github/workflows/deploy-verification-evidence.yml
@@ -71,14 +71,14 @@ jobs:
           fi
 
           cat > /tmp/deploy-evidence-comment.md <<EOF
-## Deploy verification evidence
-- Result: ${result_line}
-- Branch: \`${{ steps.ctx.outputs.head_branch }}\`
-- Commit: \`${head_short}\`
-- Run: [deploy #${{ steps.ctx.outputs.run_number }} attempt ${{ steps.ctx.outputs.run_attempt }}](${{ steps.ctx.outputs.run_url }})
-- Trigger: \`push\` to \`main\`
-- Next action: ${next_action}
-EOF
+          ## Deploy verification evidence
+          - Result: ${result_line}
+          - Branch: \`${{ steps.ctx.outputs.head_branch }}\`
+          - Commit: \`${head_short}\`
+          - Run: [deploy #${{ steps.ctx.outputs.run_number }} attempt ${{ steps.ctx.outputs.run_attempt }}](${{ steps.ctx.outputs.run_url }})
+          - Trigger: \`push\` to \`main\`
+          - Next action: ${next_action}
+          EOF
 
       - name: Post evidence to tracking issues
         if: steps.ctx.outputs.should_post == 'true'


### PR DESCRIPTION
## Summary
- fix YAML indentation in the heredoc block that builds `/tmp/deploy-evidence-comment.md`
- keep the existing runtime behavior unchanged; this patch only repairs workflow-file parsing

## Why
`deploy-verification-evidence` kept failing at 0s with no jobs. The latest run annotations showed:
- `Invalid workflow file: .github/workflows/deploy-verification-evidence.yml#L74`
- `You have an error in your yaml syntax on line 74`

The offending lines were the unindented heredoc body under `run: |`.

## Validation
- `pnpm lint`
- `pnpm typecheck`

## Expected outcome
Next push validation for this workflow should no longer fail at parse time and should materialize jobs when trigger conditions are met.

Closes #100
