### PR TITLE
fix(deploy): bound Node heap for remote Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:latest
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG BUILD_NODE_OPTIONS=--max-old-space-size=6144
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends bash build-essential ca-certificates curl gh git openssh-client ripgrep xz-utils \
@@ -29,6 +28,7 @@ RUN pnpm install --frozen-lockfile
 
 COPY . .
 COPY docker/mise.toml /app/.mise.toml
+ARG BUILD_NODE_OPTIONS=--max-old-space-size=6144
 RUN mise trust /app/.mise.toml \
   && NODE_OPTIONS="${BUILD_NODE_OPTIONS}" pnpm build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:latest
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG BUILD_NODE_OPTIONS=--max-old-space-size=6144
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends bash build-essential ca-certificates curl gh git openssh-client ripgrep xz-utils \
@@ -29,7 +30,7 @@ RUN pnpm install --frozen-lockfile
 COPY . .
 COPY docker/mise.toml /app/.mise.toml
 RUN mise trust /app/.mise.toml \
-  && pnpm build
+  && NODE_OPTIONS="${BUILD_NODE_OPTIONS}" pnpm build
 
 ENV NODE_ENV=production
 ENV NITRO_HOST=0.0.0.0


### PR DESCRIPTION
## Summary
- add `BUILD_NODE_OPTIONS` Docker build arg with default `--max-old-space-size=6144`
- apply `NODE_OPTIONS` only to the image build-time `pnpm build` command
- keep runtime container memory policy unchanged

## Why
Recent `deploy` runs on `main` failed in remote Docker build with Node heap OOM (`Reached heap limit ...`), blocking deploy reliability and follow-up evidence loops.

## Validation
- `pnpm lint`
- `pnpm typecheck`

Closes #104
