### PR TITLE
fix(actions): reduce deploy evidence comment noise by state transition

### DIFF
--- a/.github/workflows/deploy-verification-evidence.yml
+++ b/.github/workflows/deploy-verification-evidence.yml
@@ -71,7 +71,11 @@ jobs:
             if [[ -z "${trimmed}" ]]; then
               continue
             fi
-            previous_comment_body="$(gh api "repos/${REPO}/issues/${trimmed}/comments?per_page=100" --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- deploy-evidence-state:"))] | last | .body // ""')"
+            previous_comment_body="$(
+              gh api --paginate "repos/${REPO}/issues/${trimmed}/comments?per_page=100" \
+                --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- deploy-evidence-state:")) | .body' \
+                | tail -n 1
+            )"
             previous_state="$(printf '%s\n' "${previous_comment_body}" | sed -n 's/.*<!-- deploy-evidence-state:\([^>]*\) -->.*/\1/p' | head -n1)"
             current_state="${{ steps.ctx.outputs.state_key }}"
 

--- a/.github/workflows/deploy-verification-evidence.yml
+++ b/.github/workflows/deploy-verification-evidence.yml
@@ -28,9 +28,15 @@ jobs:
           conclusion="${{ github.event.workflow_run.conclusion }}"
           run_attempt="${{ github.event.workflow_run.run_attempt }}"
           should_post=true
+          state_key="${conclusion}"
 
           if [[ "${conclusion}" == "failure" && "${run_attempt}" == "1" ]]; then
             should_post=false
+            state_key="failure-initial"
+          elif [[ "${conclusion}" == "failure" ]]; then
+            state_key="failure-after-retry"
+          elif [[ "${conclusion}" == "success" ]]; then
+            state_key="success"
           fi
 
           echo "conclusion=${conclusion}" >> "$GITHUB_OUTPUT"
@@ -41,6 +47,7 @@ jobs:
           echo "head_sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
           echo "head_branch=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
           echo "should_post=${should_post}" >> "$GITHUB_OUTPUT"
+          echo "state_key=${state_key}" >> "$GITHUB_OUTPUT"
 
       - name: Retry failed deploy run once
         if: steps.ctx.outputs.conclusion == 'failure' && steps.ctx.outputs.run_attempt == '1'
@@ -51,34 +58,6 @@ jobs:
           gh api \
             --method POST \
             "repos/${REPO}/actions/runs/${{ steps.ctx.outputs.run_id }}/rerun-failed-jobs"
-
-      - name: Build evidence comment
-        if: steps.ctx.outputs.should_post == 'true'
-        run: |
-          set -euo pipefail
-
-          head_short="$(printf '%s' '${{ steps.ctx.outputs.head_sha }}' | cut -c1-12)"
-          conclusion="${{ steps.ctx.outputs.conclusion }}"
-          result_line="Deploy verification status: success"
-          next_action="None"
-
-          if [[ "${conclusion}" == "failure" ]]; then
-            result_line="Deploy verification status: failure after auto-retry"
-            next_action="Inspect failing steps and diagnostics artifact from the linked deploy run; then fix forward in the next PR."
-          elif [[ "${conclusion}" != "success" ]]; then
-            result_line="Deploy verification status: ${conclusion}"
-            next_action="Review deploy run details and decide whether a manual rerun or follow-up fix is needed."
-          fi
-
-          cat > /tmp/deploy-evidence-comment.md <<EOF
-          ## Deploy verification evidence
-          - Result: ${result_line}
-          - Branch: \`${{ steps.ctx.outputs.head_branch }}\`
-          - Commit: \`${head_short}\`
-          - Run: [deploy #${{ steps.ctx.outputs.run_number }} attempt ${{ steps.ctx.outputs.run_attempt }}](${{ steps.ctx.outputs.run_url }})
-          - Trigger: \`push\` to \`main\`
-          - Next action: ${next_action}
-          EOF
 
       - name: Post evidence to tracking issues
         if: steps.ctx.outputs.should_post == 'true'
@@ -92,5 +71,49 @@ jobs:
             if [[ -z "${trimmed}" ]]; then
               continue
             fi
+            previous_comment_body="$(gh api "repos/${REPO}/issues/${trimmed}/comments?per_page=100" --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- deploy-evidence-state:"))] | last | .body // ""')"
+            previous_state="$(printf '%s\n' "${previous_comment_body}" | sed -n 's/.*<!-- deploy-evidence-state:\([^>]*\) -->.*/\1/p' | head -n1)"
+            current_state="${{ steps.ctx.outputs.state_key }}"
+
+            if [[ "${current_state}" == "success" && ( -z "${previous_state}" || "${previous_state}" == "success" ) ]]; then
+              echo "Skipping issue #${trimmed}: no signal change for success state."
+              continue
+            fi
+
+            if [[ -n "${previous_state}" && "${previous_state}" == "${current_state}" ]]; then
+              echo "Skipping issue #${trimmed}: duplicate state ${current_state}."
+              continue
+            fi
+
+            head_short="$(printf '%s' '${{ steps.ctx.outputs.head_sha }}' | cut -c1-12)"
+            conclusion="${{ steps.ctx.outputs.conclusion }}"
+            result_line="Deploy verification status: success"
+            next_action="None"
+
+            if [[ "${conclusion}" == "failure" ]]; then
+              result_line="Deploy verification status: failure after auto-retry"
+              next_action="Inspect failing steps and diagnostics artifact from the linked deploy run; then fix forward in the next PR."
+            elif [[ "${conclusion}" != "success" ]]; then
+              result_line="Deploy verification status: ${conclusion}"
+              next_action="Review deploy run details and decide whether a manual rerun or follow-up fix is needed."
+            fi
+
+            transition_line="First tracked state in this issue."
+            if [[ -n "${previous_state}" ]]; then
+              transition_line="\`${previous_state}\` -> \`${current_state}\`"
+            fi
+
+            cat > /tmp/deploy-evidence-comment.md <<EOF
+            ## Deploy verification evidence
+            - Result: ${result_line}
+            - State transition: ${transition_line}
+            - Branch: \`${{ steps.ctx.outputs.head_branch }}\`
+            - Commit: \`${head_short}\`
+            - Run: [deploy #${{ steps.ctx.outputs.run_number }} attempt ${{ steps.ctx.outputs.run_attempt }}](${{ steps.ctx.outputs.run_url }})
+            - Trigger: \`push\` to \`main\`
+            - Next action: ${next_action}
+            <!-- deploy-evidence-state:${current_state} -->
+            EOF
+
             scripts/gh-comment-safe.sh issue "${trimmed}" --repo "${REPO}" < /tmp/deploy-evidence-comment.md
           done


### PR DESCRIPTION
## Summary
- switch deploy evidence posting to state-transition signaling instead of posting on every run
- suppress no-op `success` updates when there is no previous non-success state
- skip duplicate comments when the current state matches the last tracked state
- include a lightweight state marker in comments for deterministic dedupe

## Validation
- pnpm lint
- pnpm typecheck

Closes #107
