### PR TITLE
Harden deploy evidence comment generation path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Lint GitHub Actions workflows
+        uses: reviewdog/actionlint@v1
+
       - name: Lint
         run: pnpm run lint
 
@@ -41,6 +44,9 @@ jobs:
 
       - name: Verify startup alert regression guards
         run: pnpm run startup-alert:smoke
+
+      - name: Verify deploy evidence comment regression guards
+        run: pnpm run deploy:evidence:verify
 
       - name: Verify audio transcription regression guards
         run: pnpm run audio-transcription:verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: pnpm install
 
       - name: Lint GitHub Actions workflows
-        uses: reviewdog/actionlint@v1
+        uses: reviewdog/action-actionlint@v1
 
       - name: Lint
         run: pnpm run lint

--- a/.github/workflows/deploy-verification-evidence.yml
+++ b/.github/workflows/deploy-verification-evidence.yml
@@ -89,38 +89,15 @@ jobs:
               continue
             fi
 
-            head_short="$(printf '%s' '${{ steps.ctx.outputs.head_sha }}' | cut -c1-12)"
-            conclusion="${{ steps.ctx.outputs.conclusion }}"
-            result_line="Deploy verification status: success"
-            next_action="None"
-
-            if [[ "${conclusion}" == "failure" ]]; then
-              result_line="Deploy verification status: failure after auto-retry"
-              next_action="Inspect failing steps and diagnostics artifact from the linked deploy run; then fix forward in the next PR."
-            elif [[ "${conclusion}" != "success" ]]; then
-              result_line="Deploy verification status: ${conclusion}"
-              next_action="Review deploy run details and decide whether a manual rerun or follow-up fix is needed."
-            fi
-
-            transition_line="First tracked state in this issue."
-            if [[ -n "${previous_state}" ]]; then
-              transition_line="\`${previous_state}\` -> \`${current_state}\`"
-            fi
-
-            {
-              printf '## Deploy verification evidence\n'
-              printf -- '- Result: %s\n' "${result_line}"
-              printf -- '- State transition: %s\n' "${transition_line}"
-              printf -- '- Branch: `%s`\n' "${{ steps.ctx.outputs.head_branch }}"
-              printf -- '- Commit: `%s`\n' "${head_short}"
-              printf -- '- Run: [deploy #%s attempt %s](%s)\n' \
-                "${{ steps.ctx.outputs.run_number }}" \
-                "${{ steps.ctx.outputs.run_attempt }}" \
-                "${{ steps.ctx.outputs.run_url }}"
-              printf '%s\n' '- Trigger: `push` to `main`'
-              printf -- '- Next action: %s\n' "${next_action}"
-              printf '<!-- deploy-evidence-state:%s -->\n' "${current_state}"
-            } > /tmp/deploy-evidence-comment.md
+            DEPLOY_EVIDENCE_STATE="${current_state}" \
+            DEPLOY_EVIDENCE_PREVIOUS_STATE="${previous_state}" \
+            DEPLOY_EVIDENCE_BRANCH="${{ steps.ctx.outputs.head_branch }}" \
+            DEPLOY_EVIDENCE_HEAD_SHA="${{ steps.ctx.outputs.head_sha }}" \
+            DEPLOY_EVIDENCE_RUN_NUMBER="${{ steps.ctx.outputs.run_number }}" \
+            DEPLOY_EVIDENCE_RUN_ATTEMPT="${{ steps.ctx.outputs.run_attempt }}" \
+            DEPLOY_EVIDENCE_RUN_URL="${{ steps.ctx.outputs.run_url }}" \
+            DEPLOY_EVIDENCE_CONCLUSION="${{ steps.ctx.outputs.conclusion }}" \
+              node scripts/build-deploy-evidence-comment.mjs > /tmp/deploy-evidence-comment.md
 
             scripts/gh-comment-safe.sh issue "${trimmed}" --repo "${REPO}" < /tmp/deploy-evidence-comment.md
           done

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "chatgpt:compact:smoke": "node scripts/chatgpt-codex-compaction-smoke.ts",
     "chatgpt:smoke": "node scripts/chatgpt-codex-responses-smoke.ts",
     "startup-alert:smoke": "node scripts/startup-alert-smoke.ts",
+    "deploy:evidence:verify": "node scripts/verify-deploy-evidence-comment.mjs",
     "audio-transcription:verify": "node scripts/audio-transcription-regression-smoke.ts",
     "deploy:disk-pressure:verify": "node scripts/verify-deploy-disk-pressure-decision.mjs",
     "recovery:verify": "node scripts/verify-post-deploy-recovery.mjs",

--- a/scripts/build-deploy-evidence-comment.mjs
+++ b/scripts/build-deploy-evidence-comment.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+function required(name) {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing required env: ${name}`)
+  }
+  return value
+}
+
+const state = required('DEPLOY_EVIDENCE_STATE')
+const branch = required('DEPLOY_EVIDENCE_BRANCH')
+const headSha = required('DEPLOY_EVIDENCE_HEAD_SHA')
+const runNumber = required('DEPLOY_EVIDENCE_RUN_NUMBER')
+const runAttempt = required('DEPLOY_EVIDENCE_RUN_ATTEMPT')
+const runUrl = required('DEPLOY_EVIDENCE_RUN_URL')
+const conclusion = required('DEPLOY_EVIDENCE_CONCLUSION')
+const previousState = process.env.DEPLOY_EVIDENCE_PREVIOUS_STATE || ''
+
+const headShort = headSha.slice(0, 12)
+
+let resultLine = 'Deploy verification status: success'
+let nextAction = 'None'
+
+if (conclusion === 'failure') {
+  resultLine = 'Deploy verification status: failure after auto-retry'
+  nextAction = 'Inspect failing steps and diagnostics artifact from the linked deploy run; then fix forward in the next PR.'
+} else if (conclusion !== 'success') {
+  resultLine = `Deploy verification status: ${conclusion}`
+  nextAction = 'Review deploy run details and decide whether a manual rerun or follow-up fix is needed.'
+}
+
+let transitionLine = 'First tracked state in this issue.'
+if (previousState) {
+  transitionLine = `\`${previousState}\` -> \`${state}\``
+}
+
+const lines = [
+  '## Deploy verification evidence',
+  `- Result: ${resultLine}`,
+  `- State transition: ${transitionLine}`,
+  `- Branch: \`${branch}\``,
+  `- Commit: \`${headShort}\``,
+  `- Run: [deploy #${runNumber} attempt ${runAttempt}](${runUrl})`,
+  '- Trigger: `push` to `main`',
+  `- Next action: ${nextAction}`,
+  `<!-- deploy-evidence-state:${state} -->`
+]
+
+process.stdout.write(`${lines.join('\n')}\n`)

--- a/scripts/build-deploy-evidence-comment.mjs
+++ b/scripts/build-deploy-evidence-comment.mjs
@@ -42,7 +42,7 @@ const lines = [
   `- Branch: \`${branch}\``,
   `- Commit: \`${headShort}\``,
   `- Run: [deploy #${runNumber} attempt ${runAttempt}](${runUrl})`,
-  '- Trigger: `push` to `main`',
+  `- Trigger: \`push\` to \`${branch}\``,
   `- Next action: ${nextAction}`,
   `<!-- deploy-evidence-state:${state} -->`
 ]

--- a/scripts/verify-deploy-evidence-comment.mjs
+++ b/scripts/verify-deploy-evidence-comment.mjs
@@ -8,8 +8,12 @@ const scriptPath = new URL('./build-deploy-evidence-comment.mjs', import.meta.ur
 const scriptFilePath = fileURLToPath(scriptPath)
 
 function runCase(overrides = {}) {
+  const baseEnv = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith('DEPLOY_EVIDENCE_'))
+  )
+
   const env = {
-    ...process.env,
+    ...baseEnv,
     DEPLOY_EVIDENCE_STATE: 'success',
     DEPLOY_EVIDENCE_BRANCH: 'main',
     DEPLOY_EVIDENCE_HEAD_SHA: '0123456789abcdef0123456789abcdef01234567',

--- a/scripts/verify-deploy-evidence-comment.mjs
+++ b/scripts/verify-deploy-evidence-comment.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const scriptPath = new URL('./build-deploy-evidence-comment.mjs', import.meta.url)
+const scriptFilePath = fileURLToPath(scriptPath)
+
+function runCase(overrides = {}) {
+  const env = {
+    ...process.env,
+    DEPLOY_EVIDENCE_STATE: 'success',
+    DEPLOY_EVIDENCE_BRANCH: 'main',
+    DEPLOY_EVIDENCE_HEAD_SHA: '0123456789abcdef0123456789abcdef01234567',
+    DEPLOY_EVIDENCE_RUN_NUMBER: '77',
+    DEPLOY_EVIDENCE_RUN_ATTEMPT: '2',
+    DEPLOY_EVIDENCE_RUN_URL: 'https://example.test/run/77',
+    DEPLOY_EVIDENCE_CONCLUSION: 'success',
+    ...overrides
+  }
+
+  const result = spawnSync(process.execPath, [scriptFilePath], {
+    env,
+    encoding: 'utf8'
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+  return result.stdout
+}
+
+const successBody = runCase({
+  DEPLOY_EVIDENCE_PREVIOUS_STATE: 'failure-after-retry'
+})
+assert.match(successBody, /## Deploy verification evidence/)
+assert.match(successBody, /- State transition: `failure-after-retry` -> `success`/)
+assert.match(successBody, /- Commit: `0123456789ab`/)
+assert.match(successBody, /<!-- deploy-evidence-state:success -->/)
+
+const failureBody = runCase({
+  DEPLOY_EVIDENCE_STATE: 'failure-after-retry',
+  DEPLOY_EVIDENCE_CONCLUSION: 'failure'
+})
+assert.match(failureBody, /Deploy verification status: failure after auto-retry/)
+assert.match(failureBody, /Inspect failing steps and diagnostics artifact/)
+assert.match(failureBody, /<!-- deploy-evidence-state:failure-after-retry -->/)
+
+const neutralBody = runCase({
+  DEPLOY_EVIDENCE_STATE: 'cancelled',
+  DEPLOY_EVIDENCE_CONCLUSION: 'cancelled',
+  DEPLOY_EVIDENCE_PREVIOUS_STATE: ''
+})
+assert.match(neutralBody, /Deploy verification status: cancelled/)
+assert.match(neutralBody, /First tracked state in this issue\./)
+
+console.log('deploy evidence comment regression checks passed')


### PR DESCRIPTION
## Summary
- extract deploy evidence issue-comment markdown generation into a dedicated script (`scripts/build-deploy-evidence-comment.mjs`)
- replace inline heredoc/printf assembly in `.github/workflows/deploy-verification-evidence.yml` with script invocation
- add regression verification script (`scripts/verify-deploy-evidence-comment.mjs`) and wire it to CI
- add `actionlint` step so workflow syntax/runtime guardrails run in CI

## Validation
- `pnpm run deploy:evidence:verify`
- `pnpm run lint`
- `pnpm run typecheck`

Closes #111
