### PR TITLE
Harden deploy evidence comment rendering pipeline

### DIFF
--- a/scripts/build-deploy-evidence-comment.mjs
+++ b/scripts/build-deploy-evidence-comment.mjs
@@ -1,50 +1,16 @@
 #!/usr/bin/env node
 
-function required(name) {
-  const value = process.env[name]
-  if (!value) {
-    throw new Error(`Missing required env: ${name}`)
-  }
-  return value
-}
+import { buildDeployEvidenceCommentBody } from './lib/deploy-evidence-comment-body.mjs'
 
-const state = required('DEPLOY_EVIDENCE_STATE')
-const branch = required('DEPLOY_EVIDENCE_BRANCH')
-const headSha = required('DEPLOY_EVIDENCE_HEAD_SHA')
-const runNumber = required('DEPLOY_EVIDENCE_RUN_NUMBER')
-const runAttempt = required('DEPLOY_EVIDENCE_RUN_ATTEMPT')
-const runUrl = required('DEPLOY_EVIDENCE_RUN_URL')
-const conclusion = required('DEPLOY_EVIDENCE_CONCLUSION')
-const previousState = process.env.DEPLOY_EVIDENCE_PREVIOUS_STATE || ''
+const body = buildDeployEvidenceCommentBody({
+  state: process.env.DEPLOY_EVIDENCE_STATE,
+  branch: process.env.DEPLOY_EVIDENCE_BRANCH,
+  headSha: process.env.DEPLOY_EVIDENCE_HEAD_SHA,
+  runNumber: process.env.DEPLOY_EVIDENCE_RUN_NUMBER,
+  runAttempt: process.env.DEPLOY_EVIDENCE_RUN_ATTEMPT,
+  runUrl: process.env.DEPLOY_EVIDENCE_RUN_URL,
+  conclusion: process.env.DEPLOY_EVIDENCE_CONCLUSION,
+  previousState: process.env.DEPLOY_EVIDENCE_PREVIOUS_STATE
+})
 
-const headShort = headSha.slice(0, 12)
-
-let resultLine = 'Deploy verification status: success'
-let nextAction = 'None'
-
-if (conclusion === 'failure') {
-  resultLine = 'Deploy verification status: failure after auto-retry'
-  nextAction = 'Inspect failing steps and diagnostics artifact from the linked deploy run; then fix forward in the next PR.'
-} else if (conclusion !== 'success') {
-  resultLine = `Deploy verification status: ${conclusion}`
-  nextAction = 'Review deploy run details and decide whether a manual rerun or follow-up fix is needed.'
-}
-
-let transitionLine = 'First tracked state in this issue.'
-if (previousState) {
-  transitionLine = `\`${previousState}\` -> \`${state}\``
-}
-
-const lines = [
-  '## Deploy verification evidence',
-  `- Result: ${resultLine}`,
-  `- State transition: ${transitionLine}`,
-  `- Branch: \`${branch}\``,
-  `- Commit: \`${headShort}\``,
-  `- Run: [deploy #${runNumber} attempt ${runAttempt}](${runUrl})`,
-  `- Trigger: \`push\` to \`${branch}\``,
-  `- Next action: ${nextAction}`,
-  `<!-- deploy-evidence-state:${state} -->`
-]
-
-process.stdout.write(`${lines.join('\n')}\n`)
+process.stdout.write(body)

--- a/scripts/lib/deploy-evidence-comment-body.mjs
+++ b/scripts/lib/deploy-evidence-comment-body.mjs
@@ -12,10 +12,23 @@ function toSingleLine(value) {
 
 function inlineCode(value) {
   const normalized = toSingleLine(value)
+  if (normalized === '') {
+    return '``'
+  }
   const runs = normalized.match(/`+/g) || []
   const maxRun = runs.reduce((max, run) => Math.max(max, run.length), 0)
   const fence = '`'.repeat(maxRun + 1)
-  return `${fence}${normalized}${fence}`
+  const needsPadding = normalized.startsWith('`') || normalized.endsWith('`')
+  const padded = needsPadding ? ` ${normalized} ` : normalized
+  return `${fence}${padded}${fence}`
+}
+
+function escapeMarkdownLinkDestination(url) {
+  return toSingleLine(url).replace(/\)/g, '%29')
+}
+
+function escapeHtmlCommentBody(value) {
+  return toSingleLine(value).replace(/-->/g, '-- >')
 }
 
 export function buildDeployEvidenceCommentBody(input) {
@@ -51,10 +64,10 @@ export function buildDeployEvidenceCommentBody(input) {
     `- State transition: ${transitionLine}`,
     `- Branch: ${inlineCode(branch)}`,
     `- Commit: ${inlineCode(headShort)}`,
-    `- Run: [deploy #${toSingleLine(runNumber)} attempt ${toSingleLine(runAttempt)}](${toSingleLine(runUrl)})`,
+    `- Run: [deploy #${toSingleLine(runNumber)} attempt ${toSingleLine(runAttempt)}](${escapeMarkdownLinkDestination(runUrl)})`,
     `- Trigger: ${inlineCode('push')} to ${inlineCode(branch)}`,
     `- Next action: ${nextAction}`,
-    `<!-- deploy-evidence-state:${toSingleLine(state)} -->`
+    `<!-- deploy-evidence-state:${escapeHtmlCommentBody(state)} -->`
   ]
 
   return `${lines.join('\n')}\n`

--- a/scripts/lib/deploy-evidence-comment-body.mjs
+++ b/scripts/lib/deploy-evidence-comment-body.mjs
@@ -1,0 +1,61 @@
+function required(input, key) {
+  const value = input[key]
+  if (!value) {
+    throw new Error(`Missing required value: ${key}`)
+  }
+  return value
+}
+
+function toSingleLine(value) {
+  return String(value).replace(/\r?\n/g, ' ').replace(/[ \t]+/g, ' ').trim()
+}
+
+function inlineCode(value) {
+  const normalized = toSingleLine(value)
+  const runs = normalized.match(/`+/g) || []
+  const maxRun = runs.reduce((max, run) => Math.max(max, run.length), 0)
+  const fence = '`'.repeat(maxRun + 1)
+  return `${fence}${normalized}${fence}`
+}
+
+export function buildDeployEvidenceCommentBody(input) {
+  const state = required(input, 'state')
+  const branch = required(input, 'branch')
+  const headSha = required(input, 'headSha')
+  const runNumber = required(input, 'runNumber')
+  const runAttempt = required(input, 'runAttempt')
+  const runUrl = required(input, 'runUrl')
+  const conclusion = required(input, 'conclusion')
+  const previousState = String(input.previousState || '')
+
+  const headShort = toSingleLine(headSha).slice(0, 12)
+
+  let resultLine = 'Deploy verification status: success'
+  let nextAction = 'None'
+
+  if (conclusion === 'failure') {
+    resultLine = 'Deploy verification status: failure after auto-retry'
+    nextAction = 'Inspect failing steps and diagnostics artifact from the linked deploy run; then fix forward in the next PR.'
+  } else if (conclusion !== 'success') {
+    resultLine = `Deploy verification status: ${toSingleLine(conclusion)}`
+    nextAction = 'Review deploy run details and decide whether a manual rerun or follow-up fix is needed.'
+  }
+
+  const transitionLine = previousState
+    ? `${inlineCode(previousState)} -> ${inlineCode(state)}`
+    : 'First tracked state in this issue.'
+
+  const lines = [
+    '## Deploy verification evidence',
+    `- Result: ${resultLine}`,
+    `- State transition: ${transitionLine}`,
+    `- Branch: ${inlineCode(branch)}`,
+    `- Commit: ${inlineCode(headShort)}`,
+    `- Run: [deploy #${toSingleLine(runNumber)} attempt ${toSingleLine(runAttempt)}](${toSingleLine(runUrl)})`,
+    `- Trigger: ${inlineCode('push')} to ${inlineCode(branch)}`,
+    `- Next action: ${nextAction}`,
+    `<!-- deploy-evidence-state:${toSingleLine(state)} -->`
+  ]
+
+  return `${lines.join('\n')}\n`
+}

--- a/scripts/verify-deploy-evidence-comment.mjs
+++ b/scripts/verify-deploy-evidence-comment.mjs
@@ -58,15 +58,18 @@ assert.match(neutralBody, /Deploy verification status: cancelled/)
 assert.match(neutralBody, /First tracked state in this issue\./)
 
 const markdownStressBody = runCase({
-  DEPLOY_EVIDENCE_STATE: 'failure-after-retry',
-  DEPLOY_EVIDENCE_PREVIOUS_STATE: '```old-state```',
+  DEPLOY_EVIDENCE_STATE: 'failure-after-retry-->',
+  DEPLOY_EVIDENCE_PREVIOUS_STATE: '`old-state',
   DEPLOY_EVIDENCE_BRANCH: 'release/`hotfix`\n${{ github.sha }}',
   DEPLOY_EVIDENCE_CONCLUSION: 'failure',
   DEPLOY_EVIDENCE_RUN_NUMBER: '88',
-  DEPLOY_EVIDENCE_RUN_ATTEMPT: '3'
+  DEPLOY_EVIDENCE_RUN_ATTEMPT: '3',
+  DEPLOY_EVIDENCE_RUN_URL: 'https://example.test/run/88_(retry)'
 })
 assert.match(markdownStressBody, /- Branch: ``release\/`hotfix` \$\{\{ github\.sha \}\}``/)
 assert.match(markdownStressBody, /- Trigger: `push` to ``release\/`hotfix` \$\{\{ github\.sha \}\}``/)
-assert.match(markdownStressBody, /- State transition: `+old-state`+ -> `failure-after-retry`/)
+assert.match(markdownStressBody, /- State transition: `` `old-state `` -> `failure-after-retry-->`/)
+assert.match(markdownStressBody, /- Run: \[deploy #88 attempt 3\]\(https:\/\/example\.test\/run\/88_\(retry%29\)/)
+assert.match(markdownStressBody, /<!-- deploy-evidence-state:failure-after-retry-- > -->/)
 
 console.log('deploy evidence comment regression checks passed')

--- a/scripts/verify-deploy-evidence-comment.mjs
+++ b/scripts/verify-deploy-evidence-comment.mjs
@@ -57,4 +57,16 @@ const neutralBody = runCase({
 assert.match(neutralBody, /Deploy verification status: cancelled/)
 assert.match(neutralBody, /First tracked state in this issue\./)
 
+const markdownStressBody = runCase({
+  DEPLOY_EVIDENCE_STATE: 'failure-after-retry',
+  DEPLOY_EVIDENCE_PREVIOUS_STATE: '```old-state```',
+  DEPLOY_EVIDENCE_BRANCH: 'release/`hotfix`\n${{ github.sha }}',
+  DEPLOY_EVIDENCE_CONCLUSION: 'failure',
+  DEPLOY_EVIDENCE_RUN_NUMBER: '88',
+  DEPLOY_EVIDENCE_RUN_ATTEMPT: '3'
+})
+assert.match(markdownStressBody, /- Branch: ``release\/`hotfix` \$\{\{ github\.sha \}\}``/)
+assert.match(markdownStressBody, /- Trigger: `push` to ``release\/`hotfix` \$\{\{ github\.sha \}\}``/)
+assert.match(markdownStressBody, /- State transition: `+old-state`+ -> `failure-after-retry`/)
+
 console.log('deploy evidence comment regression checks passed')


### PR DESCRIPTION
## Summary
- extract deploy-evidence markdown body assembly into a canonical helper (`scripts/lib/deploy-evidence-comment-body.mjs`)
- harden inline markdown rendering for branch/state values with backticks, multiline content, and interpolation-like tokens
- extend regression fixtures for known rendering edge cases

## Validation
- `pnpm run deploy:evidence:verify`
- `pnpm run lint`
- `pnpm run typecheck`

Closes #113
