### PR TITLE
Implement shared deploy evidence comment rendering contract

### DIFF
--- a/scripts/lib/comment-rendering-contract.mjs
+++ b/scripts/lib/comment-rendering-contract.mjs
@@ -1,5 +1,5 @@
 export function toSingleLine(value) {
-  return String(value).replace(/\r?\n/g, ' ').replace(/[ \t]+/g, ' ').trim()
+  return String(value).replace(/\s+/g, ' ').trim()
 }
 
 export function inlineCode(value) {
@@ -17,7 +17,7 @@ export function inlineCode(value) {
 }
 
 export function escapeMarkdownLinkDestination(url) {
-  return toSingleLine(url).replace(/\)/g, '%29')
+  return encodeURI(toSingleLine(url)).replace(/\)/g, '%29')
 }
 
 export function escapeHtmlCommentBody(value) {

--- a/scripts/lib/comment-rendering-contract.mjs
+++ b/scripts/lib/comment-rendering-contract.mjs
@@ -1,0 +1,25 @@
+export function toSingleLine(value) {
+  return String(value).replace(/\r?\n/g, ' ').replace(/[ \t]+/g, ' ').trim()
+}
+
+export function inlineCode(value) {
+  const normalized = toSingleLine(value)
+  if (normalized === '') {
+    return '``'
+  }
+
+  const runs = normalized.match(/`+/g) || []
+  const maxRun = runs.reduce((max, run) => Math.max(max, run.length), 0)
+  const fence = '`'.repeat(maxRun + 1)
+  const needsPadding = normalized.startsWith('`') || normalized.endsWith('`')
+  const padded = needsPadding ? ` ${normalized} ` : normalized
+  return `${fence}${padded}${fence}`
+}
+
+export function escapeMarkdownLinkDestination(url) {
+  return toSingleLine(url).replace(/\)/g, '%29')
+}
+
+export function escapeHtmlCommentBody(value) {
+  return toSingleLine(value).replace(/-->/g, '-- >')
+}

--- a/scripts/lib/deploy-evidence-comment-body.mjs
+++ b/scripts/lib/deploy-evidence-comment-body.mjs
@@ -1,34 +1,16 @@
+import {
+  escapeHtmlCommentBody,
+  escapeMarkdownLinkDestination,
+  inlineCode,
+  toSingleLine
+} from './comment-rendering-contract.mjs'
+
 function required(input, key) {
   const value = input[key]
   if (!value) {
     throw new Error(`Missing required value: ${key}`)
   }
   return value
-}
-
-function toSingleLine(value) {
-  return String(value).replace(/\r?\n/g, ' ').replace(/[ \t]+/g, ' ').trim()
-}
-
-function inlineCode(value) {
-  const normalized = toSingleLine(value)
-  if (normalized === '') {
-    return '``'
-  }
-  const runs = normalized.match(/`+/g) || []
-  const maxRun = runs.reduce((max, run) => Math.max(max, run.length), 0)
-  const fence = '`'.repeat(maxRun + 1)
-  const needsPadding = normalized.startsWith('`') || normalized.endsWith('`')
-  const padded = needsPadding ? ` ${normalized} ` : normalized
-  return `${fence}${padded}${fence}`
-}
-
-function escapeMarkdownLinkDestination(url) {
-  return toSingleLine(url).replace(/\)/g, '%29')
-}
-
-function escapeHtmlCommentBody(value) {
-  return toSingleLine(value).replace(/-->/g, '-- >')
 }
 
 export function buildDeployEvidenceCommentBody(input) {

--- a/scripts/verify-comment-rendering-contract.mjs
+++ b/scripts/verify-comment-rendering-contract.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+import {
+  escapeHtmlCommentBody,
+  escapeMarkdownLinkDestination,
+  inlineCode,
+  toSingleLine
+} from './lib/comment-rendering-contract.mjs'
+
+const singleLineCases = [
+  {
+    name: 'newlines are collapsed',
+    input: 'release/`hotfix`\n${{ github.sha }}',
+    expected: 'release/`hotfix` ${{ github.sha }}'
+  },
+  {
+    name: 'tabs and extra spaces are normalized',
+    input: '  a\t\tb   ',
+    expected: 'a b'
+  }
+]
+
+for (const testCase of singleLineCases) {
+  assert.equal(toSingleLine(testCase.input), testCase.expected, testCase.name)
+}
+
+const inlineCodeCases = [
+  {
+    name: 'plain text uses single backticks',
+    input: 'main',
+    expected: '`main`'
+  },
+  {
+    name: 'internal backticks promote fencing',
+    input: 'release/`hotfix` ${{ github.sha }}',
+    expected: '``release/`hotfix` ${{ github.sha }}``'
+  },
+  {
+    name: 'leading backtick receives padded fence',
+    input: '`old-state',
+    expected: '`` `old-state ``'
+  },
+  {
+    name: 'empty content stays representable',
+    input: '',
+    expected: '``'
+  }
+]
+
+for (const testCase of inlineCodeCases) {
+  assert.equal(inlineCode(testCase.input), testCase.expected, testCase.name)
+}
+
+const markdownLinkCases = [
+  {
+    name: 'closing parenthesis is escaped for markdown destination',
+    input: 'https://example.test/run/88_(retry)',
+    expected: 'https://example.test/run/88_(retry%29'
+  }
+]
+
+for (const testCase of markdownLinkCases) {
+  assert.equal(
+    escapeMarkdownLinkDestination(testCase.input),
+    testCase.expected,
+    testCase.name
+  )
+}
+
+const htmlCommentCases = [
+  {
+    name: 'comment terminator is neutralized',
+    input: 'failure-after-retry-->',
+    expected: 'failure-after-retry-- >'
+  }
+]
+
+for (const testCase of htmlCommentCases) {
+  assert.equal(escapeHtmlCommentBody(testCase.input), testCase.expected, testCase.name)
+}
+
+console.log('comment rendering contract checks passed')

--- a/scripts/verify-comment-rendering-contract.mjs
+++ b/scripts/verify-comment-rendering-contract.mjs
@@ -18,6 +18,11 @@ const singleLineCases = [
     name: 'tabs and extra spaces are normalized',
     input: '  a\t\tb   ',
     expected: 'a b'
+  },
+  {
+    name: 'non-space whitespace is normalized',
+    input: 'a\vb\f c',
+    expected: 'a b c'
   }
 ]
 
@@ -57,6 +62,11 @@ const markdownLinkCases = [
     name: 'closing parenthesis is escaped for markdown destination',
     input: 'https://example.test/run/88_(retry)',
     expected: 'https://example.test/run/88_(retry%29'
+  },
+  {
+    name: 'spaces from newline boundaries are URI-escaped',
+    input: 'https://example.test/release\nnotes',
+    expected: 'https://example.test/release%20notes'
   }
 ]
 

--- a/scripts/verify-deploy-evidence-comment.mjs
+++ b/scripts/verify-deploy-evidence-comment.mjs
@@ -6,6 +6,8 @@ import { fileURLToPath } from 'node:url'
 
 const scriptPath = new URL('./build-deploy-evidence-comment.mjs', import.meta.url)
 const scriptFilePath = fileURLToPath(scriptPath)
+const contractScriptPath = new URL('./verify-comment-rendering-contract.mjs', import.meta.url)
+const contractScriptFilePath = fileURLToPath(contractScriptPath)
 
 function runCase(overrides = {}) {
   const baseEnv = Object.fromEntries(
@@ -71,5 +73,12 @@ assert.match(markdownStressBody, /- Trigger: `push` to ``release\/`hotfix` \$\{\
 assert.match(markdownStressBody, /- State transition: `` `old-state `` -> `failure-after-retry-->`/)
 assert.match(markdownStressBody, /- Run: \[deploy #88 attempt 3\]\(https:\/\/example\.test\/run\/88_\(retry%29\)/)
 assert.match(markdownStressBody, /<!-- deploy-evidence-state:failure-after-retry-- > -->/)
+
+const contractResult = spawnSync(process.execPath, [contractScriptFilePath], {
+  env: process.env,
+  encoding: 'utf8'
+})
+assert.equal(contractResult.status, 0, contractResult.stderr)
+assert.match(contractResult.stdout, /comment rendering contract checks passed/)
 
 console.log('deploy evidence comment regression checks passed')


### PR DESCRIPTION
## Summary
- extract markdown/comment-safe rendering primitives into `scripts/lib/comment-rendering-contract.mjs`
- refactor deploy evidence comment builder to consume the shared contract utility
- add table-driven regression checks for newline normalization, backtick fencing, markdown link escaping, and HTML comment safety
- execute contract checks from deploy evidence verification to keep regressions gated

## Validation
- `node scripts/verify-comment-rendering-contract.mjs`
- `node scripts/verify-deploy-evidence-comment.mjs`
- `pnpm lint`
- `pnpm typecheck`

Closes #115
