### PR TITLE
Add deploy evidence CI guardrails and fixture regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Lint GitHub Actions workflows
         uses: reviewdog/action-actionlint@v1
 
+      - name: Lint shell scripts
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: ./scripts
+
       - name: Lint
         run: pnpm run lint
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ Lease ownership regression check (Telegram poller safety):
 pnpm telegram:lease:smoke
 ```
 
+Deploy evidence comment regression checks:
+
+```bash
+pnpm deploy:evidence:verify
+```
+
+When changing deploy evidence generation or related workflow shell/YAML:
+- Keep the fixture regressions in `scripts/fixtures/deploy-evidence-comment-cases.json` updated.
+- Ensure CI checks for `actionlint`, `shellcheck`, and `deploy:evidence:verify` remain green before merge.
+
 Optional runtime mode:
 - `CORAZON_CODEX_CLIENT_MODE=app-server` (default)
 - `CORAZON_CODEX_CLIENT_MODE=sdk` (fallback)

--- a/scripts/fixtures/deploy-evidence-comment-cases.json
+++ b/scripts/fixtures/deploy-evidence-comment-cases.json
@@ -42,15 +42,15 @@
     "env": {
       "DEPLOY_EVIDENCE_STATE": "failure-after-retry-->",
       "DEPLOY_EVIDENCE_PREVIOUS_STATE": "`old-state",
-      "DEPLOY_EVIDENCE_BRANCH": "release/`hotfix`\\n${{ github.sha }}",
+      "DEPLOY_EVIDENCE_BRANCH": "release/`hotfix`\n${{ github.sha }}",
       "DEPLOY_EVIDENCE_CONCLUSION": "failure",
       "DEPLOY_EVIDENCE_RUN_NUMBER": "88",
       "DEPLOY_EVIDENCE_RUN_ATTEMPT": "3",
       "DEPLOY_EVIDENCE_RUN_URL": "https://example.test/run/88_(retry)"
     },
     "patterns": [
-      "- Branch: ``release/`hotfix`\\n${{ github.sha }}``",
-      "- Trigger: `push` to ``release/`hotfix`\\n${{ github.sha }}``",
+      "- Branch: ``release/`hotfix` ${{ github.sha }}``",
+      "- Trigger: `push` to ``release/`hotfix` ${{ github.sha }}``",
       "- State transition: `` `old-state `` -> `failure-after-retry-->`",
       "- Run: [deploy #88 attempt 3](https://example.test/run/88_(retry%29)",
       "<!-- deploy-evidence-state:failure-after-retry-- > -->"

--- a/scripts/fixtures/deploy-evidence-comment-cases.json
+++ b/scripts/fixtures/deploy-evidence-comment-cases.json
@@ -1,0 +1,59 @@
+[
+  {
+    "name": "success-transition-from-failure",
+    "env": {
+      "DEPLOY_EVIDENCE_STATE": "success",
+      "DEPLOY_EVIDENCE_PREVIOUS_STATE": "failure-after-retry",
+      "DEPLOY_EVIDENCE_CONCLUSION": "success"
+    },
+    "patterns": [
+      "## Deploy verification evidence",
+      "- State transition: `failure-after-retry` -> `success`",
+      "- Commit: `0123456789ab`",
+      "<!-- deploy-evidence-state:success -->"
+    ]
+  },
+  {
+    "name": "failure-after-retry",
+    "env": {
+      "DEPLOY_EVIDENCE_STATE": "failure-after-retry",
+      "DEPLOY_EVIDENCE_CONCLUSION": "failure"
+    },
+    "patterns": [
+      "Deploy verification status: failure after auto-retry",
+      "Inspect failing steps and diagnostics artifact",
+      "<!-- deploy-evidence-state:failure-after-retry -->"
+    ]
+  },
+  {
+    "name": "cancelled-first-state",
+    "env": {
+      "DEPLOY_EVIDENCE_STATE": "cancelled",
+      "DEPLOY_EVIDENCE_CONCLUSION": "cancelled",
+      "DEPLOY_EVIDENCE_PREVIOUS_STATE": ""
+    },
+    "patterns": [
+      "Deploy verification status: cancelled",
+      "First tracked state in this issue."
+    ]
+  },
+  {
+    "name": "heredoc-and-quoting-stress",
+    "env": {
+      "DEPLOY_EVIDENCE_STATE": "failure-after-retry-->",
+      "DEPLOY_EVIDENCE_PREVIOUS_STATE": "`old-state",
+      "DEPLOY_EVIDENCE_BRANCH": "release/`hotfix`\\n${{ github.sha }}",
+      "DEPLOY_EVIDENCE_CONCLUSION": "failure",
+      "DEPLOY_EVIDENCE_RUN_NUMBER": "88",
+      "DEPLOY_EVIDENCE_RUN_ATTEMPT": "3",
+      "DEPLOY_EVIDENCE_RUN_URL": "https://example.test/run/88_(retry)"
+    },
+    "patterns": [
+      "- Branch: ``release/`hotfix`\\n${{ github.sha }}``",
+      "- Trigger: `push` to ``release/`hotfix`\\n${{ github.sha }}``",
+      "- State transition: `` `old-state `` -> `failure-after-retry-->`",
+      "- Run: [deploy #88 attempt 3](https://example.test/run/88_(retry%29)",
+      "<!-- deploy-evidence-state:failure-after-retry-- > -->"
+    ]
+  }
+]

--- a/scripts/gh-issue-feedback.sh
+++ b/scripts/gh-issue-feedback.sh
@@ -101,6 +101,7 @@ process.stdout.write(String(Array.isArray(payload) ? payload.length : 0))
 gh api "repos/${repo}/issues/${issue_number}" >"$issue_file"
 fetch_paginated_arrays "repos/${repo}/issues/${issue_number}/comments" "$comments_file"
 
+# shellcheck disable=SC2016
 node -e '
 const fs = require("node:fs")
 const [issuePath, commentsPath] = process.argv.slice(1)

--- a/scripts/gh-pr-feedback.sh
+++ b/scripts/gh-pr-feedback.sh
@@ -115,6 +115,7 @@ wait "$pid_issue_comments"
 wait "$pid_review_comments"
 wait "$pid_reviews"
 
+# shellcheck disable=SC2016
 node -e '
 const fs = require("node:fs")
 const [pullPath, issuePath, reviewCommentPath, reviewsPath] = process.argv.slice(1)

--- a/scripts/verify-deploy-evidence-comment.mjs
+++ b/scripts/verify-deploy-evidence-comment.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
@@ -8,6 +9,7 @@ const scriptPath = new URL('./build-deploy-evidence-comment.mjs', import.meta.ur
 const scriptFilePath = fileURLToPath(scriptPath)
 const contractScriptPath = new URL('./verify-comment-rendering-contract.mjs', import.meta.url)
 const contractScriptFilePath = fileURLToPath(contractScriptPath)
+const fixturePath = new URL('./fixtures/deploy-evidence-comment-cases.json', import.meta.url)
 
 function runCase(overrides = {}) {
   const baseEnv = Object.fromEntries(
@@ -35,44 +37,13 @@ function runCase(overrides = {}) {
   return result.stdout
 }
 
-const successBody = runCase({
-  DEPLOY_EVIDENCE_PREVIOUS_STATE: 'failure-after-retry'
-})
-assert.match(successBody, /## Deploy verification evidence/)
-assert.match(successBody, /- State transition: `failure-after-retry` -> `success`/)
-assert.match(successBody, /- Commit: `0123456789ab`/)
-assert.match(successBody, /<!-- deploy-evidence-state:success -->/)
-
-const failureBody = runCase({
-  DEPLOY_EVIDENCE_STATE: 'failure-after-retry',
-  DEPLOY_EVIDENCE_CONCLUSION: 'failure'
-})
-assert.match(failureBody, /Deploy verification status: failure after auto-retry/)
-assert.match(failureBody, /Inspect failing steps and diagnostics artifact/)
-assert.match(failureBody, /<!-- deploy-evidence-state:failure-after-retry -->/)
-
-const neutralBody = runCase({
-  DEPLOY_EVIDENCE_STATE: 'cancelled',
-  DEPLOY_EVIDENCE_CONCLUSION: 'cancelled',
-  DEPLOY_EVIDENCE_PREVIOUS_STATE: ''
-})
-assert.match(neutralBody, /Deploy verification status: cancelled/)
-assert.match(neutralBody, /First tracked state in this issue\./)
-
-const markdownStressBody = runCase({
-  DEPLOY_EVIDENCE_STATE: 'failure-after-retry-->',
-  DEPLOY_EVIDENCE_PREVIOUS_STATE: '`old-state',
-  DEPLOY_EVIDENCE_BRANCH: 'release/`hotfix`\n${{ github.sha }}',
-  DEPLOY_EVIDENCE_CONCLUSION: 'failure',
-  DEPLOY_EVIDENCE_RUN_NUMBER: '88',
-  DEPLOY_EVIDENCE_RUN_ATTEMPT: '3',
-  DEPLOY_EVIDENCE_RUN_URL: 'https://example.test/run/88_(retry)'
-})
-assert.match(markdownStressBody, /- Branch: ``release\/`hotfix` \$\{\{ github\.sha \}\}``/)
-assert.match(markdownStressBody, /- Trigger: `push` to ``release\/`hotfix` \$\{\{ github\.sha \}\}``/)
-assert.match(markdownStressBody, /- State transition: `` `old-state `` -> `failure-after-retry-->`/)
-assert.match(markdownStressBody, /- Run: \[deploy #88 attempt 3\]\(https:\/\/example\.test\/run\/88_\(retry%29\)/)
-assert.match(markdownStressBody, /<!-- deploy-evidence-state:failure-after-retry-- > -->/)
+const fixtures = JSON.parse(readFileSync(fileURLToPath(fixturePath), 'utf8'))
+for (const fixture of fixtures) {
+  const body = runCase(fixture.env)
+  for (const expectedSnippet of fixture.patterns) {
+    assert.ok(body.includes(expectedSnippet), `${fixture.name} missing snippet: ${expectedSnippet}`)
+  }
+}
 
 const contractResult = spawnSync(process.execPath, [contractScriptFilePath], {
   env: process.env,
@@ -81,4 +52,4 @@ const contractResult = spawnSync(process.execPath, [contractScriptFilePath], {
 assert.equal(contractResult.status, 0, contractResult.stderr)
 assert.match(contractResult.stdout, /comment rendering contract checks passed/)
 
-console.log('deploy evidence comment regression checks passed')
+console.log(`deploy evidence comment regression checks passed (${fixtures.length} fixture cases)`)


### PR DESCRIPTION
## Summary
- add CI `shellcheck` gating for scripts under `scripts/`
- convert deploy evidence regression verification to fixture-driven cases
- add dedicated heredoc/quoting regression fixture plus existing state-transition cases
- document required deploy evidence verification checks in README

## Validation
- `pnpm run deploy:evidence:verify`
- `pnpm run lint`

Closes #117
