### PR TITLE
Add bounded deploy-evidence fuzz/property regression harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v4.4.0
 
       - name: Install node
         uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -48,8 +48,15 @@ Deploy evidence comment regression checks:
 pnpm deploy:evidence:verify
 ```
 
+Deterministic fuzz/property replay for deploy-evidence rendering:
+
+```bash
+DEPLOY_EVIDENCE_FUZZ_SEED=118113 DEPLOY_EVIDENCE_FUZZ_ITERATIONS=120 pnpm deploy:evidence:verify
+```
+
 When changing deploy evidence generation or related workflow shell/YAML:
 - Keep the fixture regressions in `scripts/fixtures/deploy-evidence-comment-cases.json` updated.
+- Keep deterministic seed coverage in `scripts/fixtures/deploy-evidence-fuzz-seeds.json` updated.
 - Ensure CI checks for `actionlint`, `shellcheck`, and `deploy:evidence:verify` remain green before merge.
 
 Optional runtime mode:

--- a/scripts/fixtures/deploy-evidence-fuzz-seeds.json
+++ b/scripts/fixtures/deploy-evidence-fuzz-seeds.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "baseline-seed",
+    "seed": 424242,
+    "iterations": 40
+  },
+  {
+    "name": "adversarial-markdown-heredoc-seed",
+    "seed": 118113,
+    "iterations": 40
+  }
+]

--- a/scripts/verify-deploy-evidence-comment.mjs
+++ b/scripts/verify-deploy-evidence-comment.mjs
@@ -9,6 +9,8 @@ const scriptPath = new URL('./build-deploy-evidence-comment.mjs', import.meta.ur
 const scriptFilePath = fileURLToPath(scriptPath)
 const contractScriptPath = new URL('./verify-comment-rendering-contract.mjs', import.meta.url)
 const contractScriptFilePath = fileURLToPath(contractScriptPath)
+const fuzzScriptPath = new URL('./verify-deploy-evidence-fuzz.mjs', import.meta.url)
+const fuzzScriptFilePath = fileURLToPath(fuzzScriptPath)
 const fixturePath = new URL('./fixtures/deploy-evidence-comment-cases.json', import.meta.url)
 
 function runCase(overrides = {}) {
@@ -52,4 +54,13 @@ const contractResult = spawnSync(process.execPath, [contractScriptFilePath], {
 assert.equal(contractResult.status, 0, contractResult.stderr)
 assert.match(contractResult.stdout, /comment rendering contract checks passed/)
 
-console.log(`deploy evidence comment regression checks passed (${fixtures.length} fixture cases)`)
+const fuzzResult = spawnSync(process.execPath, [fuzzScriptFilePath], {
+  env: process.env,
+  encoding: 'utf8'
+})
+assert.equal(fuzzResult.status, 0, fuzzResult.stderr)
+assert.match(fuzzResult.stdout, /deploy evidence fuzz\/property checks passed/)
+
+console.log(
+  `deploy evidence comment regression checks passed (${fixtures.length} fixture cases + deterministic fuzz/property harness)`
+)

--- a/scripts/verify-deploy-evidence-fuzz.mjs
+++ b/scripts/verify-deploy-evidence-fuzz.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { buildDeployEvidenceCommentBody } from './lib/deploy-evidence-comment-body.mjs'
+
+const seedsPath = new URL('./fixtures/deploy-evidence-fuzz-seeds.json', import.meta.url)
+const configuredSeeds = JSON.parse(readFileSync(fileURLToPath(seedsPath), 'utf8'))
+
+const forcedSeed = process.env.DEPLOY_EVIDENCE_FUZZ_SEED
+const forcedIterations = Number(process.env.DEPLOY_EVIDENCE_FUZZ_ITERATIONS || 0)
+
+const runs = forcedSeed
+  ? [{ name: 'manual-seed', seed: Number(forcedSeed), iterations: forcedIterations || 120 }]
+  : configuredSeeds
+
+let totalCases = 0
+
+for (const run of runs) {
+  verifyRun(run)
+}
+
+console.log(
+  `deploy evidence fuzz/property checks passed (${totalCases} generated cases across ${runs.length} seed run(s))`
+)
+
+function verifyRun({ name, seed, iterations }) {
+  assert.ok(Number.isInteger(seed), `${name}: seed must be an integer`)
+  assert.ok(Number.isInteger(iterations) && iterations > 0, `${name}: iterations must be > 0`)
+
+  const rng = makeRng(seed)
+  for (let i = 0; i < iterations; i++) {
+    const input = generateInput(rng, i)
+    const body = buildDeployEvidenceCommentBody(input)
+    assertInvariants({ body, input, name, seed, index: i })
+    totalCases += 1
+  }
+}
+
+function makeRng(seed) {
+  let state = seed >>> 0
+  return function next() {
+    state = (1664525 * state + 1013904223) >>> 0
+    return state / 4294967296
+  }
+}
+
+function pick(rng, items) {
+  return items[Math.floor(rng() * items.length)]
+}
+
+function randomInt(rng, maxExclusive) {
+  return Math.floor(rng() * maxExclusive)
+}
+
+function randomToken(rng, maxTokens = 6) {
+  const lexicon = [
+    'main',
+    'release',
+    'hotfix',
+    'staging',
+    'prod',
+    'workflow',
+    '```',
+    '`inline`',
+    '${{ github.sha }}',
+    '$(rm -rf /)',
+    'EOF',
+    '<<EOF',
+    '-->',
+    'retry)',
+    'line\nbreak'
+  ]
+  const count = 1 + randomInt(rng, maxTokens)
+  let value = ''
+  for (let i = 0; i < count; i++) {
+    value += (i > 0 ? pick(rng, [' ', '  ', '\n', '\t']) : '') + pick(rng, lexicon)
+  }
+  return value
+}
+
+function randomSha(rng) {
+  const hex = '0123456789abcdef'
+  let value = ''
+  for (let i = 0; i < 40; i++) {
+    value += hex[randomInt(rng, hex.length)]
+  }
+  return value
+}
+
+function generateInput(rng, index) {
+  const state = randomToken(rng, 4)
+  const previousState = rng() < 0.5 ? '' : randomToken(rng, 4)
+  const branch = randomToken(rng, 5)
+  const headSha = randomSha(rng)
+  const runNumber = String(1 + randomInt(rng, 5000))
+  const runAttempt = String(1 + randomInt(rng, 5))
+  const conclusion = pick(rng, ['success', 'failure', 'cancelled', 'timed_out', randomToken(rng, 2)])
+  const runUrl = `https://example.test/run/${runNumber}_${randomToken(rng, 3)}/${index}(retry)`
+
+  return {
+    state,
+    previousState,
+    branch,
+    headSha,
+    runNumber,
+    runAttempt,
+    runUrl,
+    conclusion
+  }
+}
+
+function assertInvariants({ body, input, name, seed, index }) {
+  const context = `${name} seed=${seed} case=${index}`
+
+  assert.ok(body.endsWith('\n'), `${context}: output must end with newline`)
+  assert.equal(body.split('\n').length, 10, `${context}: output must stay 9-line body + trailing newline`)
+  assert.match(body, /^## Deploy verification evidence\n/m, `${context}: header missing`)
+  assert.match(body, /<!-- deploy-evidence-state:[\s\S]* -->\n$/, `${context}: sentinel comment missing`)
+  assert.ok(!body.includes('<!-- deploy-evidence-state:-->'), `${context}: empty sentinel state`)
+  assert.ok(!body.includes('<!-- deploy-evidence-state:-->\n'), `${context}: raw terminator leaked into sentinel`)
+  assert.ok(!body.includes('\r'), `${context}: carriage return should not appear`)
+
+  const triggerLine = body.split('\n').find((line) => line.startsWith('- Trigger: ')) || ''
+  assert.ok(!triggerLine.includes('\n'), `${context}: trigger line must be single-line`)
+
+  const runLine = body.split('\n').find((line) => line.startsWith('- Run: ')) || ''
+  assert.ok(runLine.includes('%29'), `${context}: run link should escape closing parenthesis`)
+  assert.ok(!runLine.includes('\n'), `${context}: run line must be single-line`)
+
+  const expectedCommitSnippet = `- Commit: \`${String(input.headSha).slice(0, 12)}\``
+  assert.ok(body.includes(expectedCommitSnippet), `${context}: commit short SHA invariant violated`)
+}

--- a/scripts/verify-deploy-evidence-fuzz.mjs
+++ b/scripts/verify-deploy-evidence-fuzz.mjs
@@ -122,12 +122,8 @@ function assertInvariants({ body, input, name, seed, index }) {
   assert.ok(!body.includes('<!-- deploy-evidence-state:-->\n'), `${context}: raw terminator leaked into sentinel`)
   assert.ok(!body.includes('\r'), `${context}: carriage return should not appear`)
 
-  const triggerLine = body.split('\n').find((line) => line.startsWith('- Trigger: ')) || ''
-  assert.ok(!triggerLine.includes('\n'), `${context}: trigger line must be single-line`)
-
-  const runLine = body.split('\n').find((line) => line.startsWith('- Run: ')) || ''
+  const runLine = body.split('\n').find(line => line.startsWith('- Run: ')) || ''
   assert.ok(runLine.includes('%29'), `${context}: run link should escape closing parenthesis`)
-  assert.ok(!runLine.includes('\n'), `${context}: run line must be single-line`)
 
   const expectedCommitSnippet = `- Commit: \`${String(input.headSha).slice(0, 12)}\``
   assert.ok(body.includes(expectedCommitSnippet), `${context}: commit short SHA invariant violated`)


### PR DESCRIPTION
## Summary
- add a deterministic seed-based fuzz/property regression harness for deploy-evidence comment rendering
- wire fuzz verification into `pnpm deploy:evidence:verify` so CI executes it on PRs
- document seed replay and maintainable seed fixtures

## Why
Implements #119 to reduce recurrence of escaping/newline/heredoc regressions with bounded randomized coverage.

## Validation
- `pnpm run deploy:evidence:verify`
- `DEPLOY_EVIDENCE_FUZZ_SEED=118113 DEPLOY_EVIDENCE_FUZZ_ITERATIONS=20 pnpm run deploy:evidence:verify`

Closes #119
